### PR TITLE
[BUGFIX] Convert subscribers to tracers to handle class autoload errors

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -21,6 +21,26 @@ parameters:
 			path: tests/e2e/requires-class-attribute/fixtures/fail-on-unsatisfied-requirement/tests/RequiresClassAttributeFailsOnUnsatisfiedRequirementTest.php
 
 		-
+			message: "#^Instantiated class EliasHaeussler\\\\PHPUnitAttributes\\\\Tests\\\\E2E\\\\Foo not found\\.$#"
+			count: 1
+			path: tests/e2e/requires-class-attribute/fixtures/handle-autoload-errors/tests/RequiresClassAttributeHandlesAutoloadErrorsTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$className of attribute class EliasHaeussler\\\\PHPUnitAttributes\\\\Attribute\\\\RequiresClass constructor expects class\\-string, string given\\.$#"
+			count: 1
+			path: tests/e2e/requires-class-attribute/fixtures/handle-autoload-errors/tests/RequiresClassAttributeHandlesAutoloadErrorsTest.php
+
+		-
+			message: "#^Property EliasHaeussler\\\\PHPUnitAttributes\\\\Tests\\\\E2E\\\\RequiresClassAttributeHandlesAutoloadErrorsTest\\:\\:\\$foo has unknown class EliasHaeussler\\\\PHPUnitAttributes\\\\Tests\\\\E2E\\\\Foo as its type\\.$#"
+			count: 1
+			path: tests/e2e/requires-class-attribute/fixtures/handle-autoload-errors/tests/RequiresClassAttributeHandlesAutoloadErrorsTest.php
+
+		-
+			message: "#^Property EliasHaeussler\\\\PHPUnitAttributes\\\\Tests\\\\E2E\\\\RequiresClassAttributeHandlesAutoloadErrorsTest\\:\\:\\$foo is never read, only written\\.$#"
+			count: 1
+			path: tests/e2e/requires-class-attribute/fixtures/handle-autoload-errors/tests/RequiresClassAttributeHandlesAutoloadErrorsTest.php
+
+		-
 			message: "#^Parameter \\#1 \\$className of attribute class EliasHaeussler\\\\PHPUnitAttributes\\\\Attribute\\\\RequiresClass constructor expects class\\-string, string given\\.$#"
 			count: 1
 			path: tests/e2e/requires-class-attribute/fixtures/method-level/tests/RepeatedRequiresClassAttributeTest.php
@@ -44,6 +64,21 @@ parameters:
 			message: "#^Parameter \\#1 \\$className of attribute class EliasHaeussler\\\\PHPUnitAttributes\\\\Attribute\\\\RequiresClass constructor expects class\\-string, string given\\.$#"
 			count: 1
 			path: tests/e2e/requires-class-attribute/fixtures/skip-on-unsatisfied-requirement/tests/RequiresClassAttributeSkipsOnUnsatisfiedRequirementTest.php
+
+		-
+			message: "#^Instantiated class EliasHaeussler\\\\PHPUnitAttributes\\\\Tests\\\\E2E\\\\Foo not found\\.$#"
+			count: 1
+			path: tests/e2e/requires-package-attribute/fixtures/handle-autoload-errors/tests/RequiresPackageAttributeHandlesAutoloadErrorsTest.php
+
+		-
+			message: "#^Property EliasHaeussler\\\\PHPUnitAttributes\\\\Tests\\\\E2E\\\\RequiresPackageAttributeHandlesAutoloadErrorsTest\\:\\:\\$foo has unknown class EliasHaeussler\\\\PHPUnitAttributes\\\\Tests\\\\E2E\\\\Foo as its type\\.$#"
+			count: 1
+			path: tests/e2e/requires-package-attribute/fixtures/handle-autoload-errors/tests/RequiresPackageAttributeHandlesAutoloadErrorsTest.php
+
+		-
+			message: "#^Property EliasHaeussler\\\\PHPUnitAttributes\\\\Tests\\\\E2E\\\\RequiresPackageAttributeHandlesAutoloadErrorsTest\\:\\:\\$foo is never read, only written\\.$#"
+			count: 1
+			path: tests/e2e/requires-package-attribute/fixtures/handle-autoload-errors/tests/RequiresPackageAttributeHandlesAutoloadErrorsTest.php
 
 		-
 			message: "#^Parameter \\#1 \\$className of class EliasHaeussler\\\\PHPUnitAttributes\\\\Attribute\\\\RequiresClass constructor expects class\\-string, string given\\.$#"

--- a/src/Event/Tracer/RequiresClassAttributeTracer.php
+++ b/src/Event/Tracer/RequiresClassAttributeTracer.php
@@ -21,7 +21,7 @@ declare(strict_types=1);
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
-namespace EliasHaeussler\PHPUnitAttributes\Event\Subscriber;
+namespace EliasHaeussler\PHPUnitAttributes\Event\Tracer;
 
 use EliasHaeussler\PHPUnitAttributes\Attribute;
 use EliasHaeussler\PHPUnitAttributes\Enum;
@@ -36,32 +36,48 @@ use function array_values;
 use function implode;
 
 /**
- * RequiresPackageAttributeSubscriber.
+ * RequiresClassAttributeTracer.
  *
  * @author Elias Häußler <elias@haeussler.dev>
  * @license GPL-3.0-or-later
  */
-final class RequiresPackageAttributeSubscriber implements Event\Test\PreparedSubscriber
+final class RequiresClassAttributeTracer implements Event\Tracer\Tracer
 {
     /**
-     * @var array<non-empty-string, array<non-empty-string, Enum\OutcomeBehavior>>
+     * @var array<class-string, array<non-empty-string, Enum\OutcomeBehavior>>
      */
     private array $testClassBehaviorsCache = [];
 
     public function __construct(
-        private readonly Metadata\PackageRequirements $packageRequirements,
-        private readonly Enum\OutcomeBehavior $behaviorOnUnsatisfiedPackageRequirements,
+        private readonly Metadata\ClassRequirements $classRequirements,
+        private readonly Enum\OutcomeBehavior $behaviorOnMissingClasses,
     ) {}
 
-    public function notify(Event\Test\Prepared $event): void
+    public function trace(Event\Event $event): void
     {
-        $test = $event->test();
+        if ($event instanceof Event\Test\BeforeTestMethodCalled) {
+            $this->processAttributesOnClassLevel($event->testClassName());
 
-        if (!($test instanceof Event\Code\TestMethod)) {
             return;
         }
 
-        $testClassName = $test->className();
+        if (!($event instanceof Event\Test\Prepared)) {
+            return;
+        }
+
+        $test = $event->test();
+
+        if ($test instanceof Event\Code\TestMethod) {
+            $this->processAttributesOnClassLevel($test->className());
+            $this->processAttributesOnMethodLevel($test->className(), $test->methodName());
+        }
+    }
+
+    /**
+     * @param class-string $testClassName
+     */
+    private function processAttributesOnClassLevel(string $testClassName): void
+    {
         $behaviors = $this->testClassBehaviorsCache[$testClassName] ?? [];
 
         if ([] !== $behaviors) {
@@ -70,20 +86,9 @@ final class RequiresPackageAttributeSubscriber implements Event\Test\PreparedSub
 
         $classAttributes = Reflection\AttributeReflector::forClass(
             $testClassName,
-            Attribute\RequiresPackage::class,
+            Attribute\RequiresClass::class,
         );
-        $behaviors = $this->testClassBehaviorsCache[$testClassName] = $this->checkPackageRequirements($classAttributes);
-
-        if ([] !== $behaviors) {
-            $this->handleOutcomeBehavior($behaviors);
-        }
-
-        $methodAttributes = Reflection\AttributeReflector::forClassMethod(
-            $testClassName,
-            $test->methodName(),
-            Attribute\RequiresPackage::class,
-        );
-        $behaviors = $this->checkPackageRequirements($methodAttributes);
+        $behaviors = $this->testClassBehaviorsCache[$testClassName] = $this->checkClassNames($classAttributes);
 
         if ([] !== $behaviors) {
             $this->handleOutcomeBehavior($behaviors);
@@ -91,19 +96,36 @@ final class RequiresPackageAttributeSubscriber implements Event\Test\PreparedSub
     }
 
     /**
-     * @param list<Attribute\RequiresPackage> $attributes
+     * @param class-string $testClassName
+     */
+    private function processAttributesOnMethodLevel(string $testClassName, string $testMethodName): void
+    {
+        $methodAttributes = Reflection\AttributeReflector::forClassMethod(
+            $testClassName,
+            $testMethodName,
+            Attribute\RequiresClass::class,
+        );
+        $behaviors = $this->checkClassNames($methodAttributes);
+
+        if ([] !== $behaviors) {
+            $this->handleOutcomeBehavior($behaviors);
+        }
+    }
+
+    /**
+     * @param list<Attribute\RequiresClass> $attributes
      *
      * @return array<non-empty-string, Enum\OutcomeBehavior>
      */
-    private function checkPackageRequirements(array $attributes): array
+    private function checkClassNames(array $attributes): array
     {
         $notSatisfied = [];
 
         foreach ($attributes as $attribute) {
-            $message = $this->packageRequirements->validateForAttribute($attribute);
+            $message = $this->classRequirements->validateForAttribute($attribute);
 
             if (null !== $message) {
-                $notSatisfied[$message] = $attribute->outcomeBehavior() ?? $this->behaviorOnUnsatisfiedPackageRequirements;
+                $notSatisfied[$message] = $attribute->outcomeBehavior() ?? $this->behaviorOnMissingClasses;
             }
         }
 
@@ -123,7 +145,7 @@ final class RequiresPackageAttributeSubscriber implements Event\Test\PreparedSub
             ),
         );
 
-        match (Enum\OutcomeBehavior::fromSet($outcomeBehaviors) ?? $this->behaviorOnUnsatisfiedPackageRequirements) {
+        match (Enum\OutcomeBehavior::fromSet($outcomeBehaviors) ?? $this->behaviorOnMissingClasses) {
             Enum\OutcomeBehavior::Fail => Framework\Assert::fail($message),
             Enum\OutcomeBehavior::Skip => Framework\Assert::markTestSkipped($message),
         };

--- a/src/PHPUnitAttributesExtension.php
+++ b/src/PHPUnitAttributesExtension.php
@@ -45,12 +45,14 @@ final class PHPUnitAttributesExtension implements Runner\Extension\Extension
     ): void {
         [$requiresPackageMigrationResult, $requiresClassMigrationResult] = $this->migrateConfigurationParameters($parameters);
 
-        $facade->registerSubscribers(
-            new Event\Subscriber\RequiresPackageAttributeSubscriber(
+        $facade->registerTracer(
+            new Event\Tracer\RequiresPackageAttributeTracer(
                 new Metadata\PackageRequirements(),
                 Enum\OutcomeBehavior::tryFrom($requiresPackageMigrationResult->value()) ?? Enum\OutcomeBehavior::Skip,
             ),
-            new Event\Subscriber\RequiresClassAttributeSubscriber(
+        );
+        $facade->registerTracer(
+            new Event\Tracer\RequiresClassAttributeTracer(
                 new Metadata\ClassRequirements(),
                 Enum\OutcomeBehavior::tryFrom($requiresClassMigrationResult->value()) ?? Enum\OutcomeBehavior::Skip,
             ),

--- a/tests/e2e/requires-class-attribute/fail-on-unsatisfied-requirement.phpt
+++ b/tests/e2e/requires-class-attribute/fail-on-unsatisfied-requirement.phpt
@@ -29,6 +29,7 @@ Class "Foo\Baz" is required.
 
 %s
 %s
+%s
 
 FAILURES!
 Tests: 2, Assertions: 2, Failures: 1.

--- a/tests/e2e/requires-class-attribute/fixtures/handle-autoload-errors/phpunit.xml
+++ b/tests/e2e/requires-class-attribute/fixtures/handle-autoload-errors/phpunit.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="../../../../../vendor/phpunit/phpunit/phpunit.xsd"
+>
+    <extensions>
+        <bootstrap class="EliasHaeussler\PHPUnitAttributes\PHPUnitAttributesExtension" />
+    </extensions>
+    <testsuites>
+        <testsuite name="default">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/tests/e2e/requires-class-attribute/fixtures/handle-autoload-errors/tests/RequiresClassAttributeHandlesAutoloadErrorsTest.php
+++ b/tests/e2e/requires-class-attribute/fixtures/handle-autoload-errors/tests/RequiresClassAttributeHandlesAutoloadErrorsTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/phpunit-attributes".
+ *
+ * Copyright (C) 2024 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\PHPUnitAttributes\Tests\E2E;
+
+use EliasHaeussler\PHPUnitAttributes as Src;
+use PHPUnit\Framework;
+
+/**
+ * RequiresClassAttributeHandlesAutoloadErrorsTest.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ */
+#[Src\Attribute\RequiresClass('Foo\\Baz')]
+final class RequiresClassAttributeHandlesAutoloadErrorsTest extends Framework\TestCase
+{
+    private Foo $foo;
+
+    protected function setUp(): void
+    {
+        $this->foo = new Foo();
+    }
+
+    #[Framework\Attributes\Test]
+    public function fakeTest(): void
+    {
+        self::assertTrue(true);
+    }
+
+    #[Framework\Attributes\Test]
+    public function anotherFakeTest(): void
+    {
+        self::assertTrue(true);
+    }
+}

--- a/tests/e2e/requires-class-attribute/handle-autoload-errors.phpt
+++ b/tests/e2e/requires-class-attribute/handle-autoload-errors.phpt
@@ -1,0 +1,35 @@
+--TEST--
+Autoload errors in before methods are properly handled
+--FILE--
+<?php
+
+declare(strict_types=1);
+
+$_SERVER['argv'][] = '--do-not-cache-result';
+$_SERVER['argv'][] = '--display-skipped';
+$_SERVER['argv'][] = '--configuration';
+$_SERVER['argv'][] = __DIR__ . '/fixtures/handle-autoload-errors/phpunit.xml';
+
+require dirname(__DIR__, 3) . '/vendor/autoload.php';
+
+(new \PHPUnit\TextUI\Application())->run($_SERVER['argv']);
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+Runtime: %s
+Configuration: %s
+
+SS                                                                  2 / 2 (100%)
+
+Time: %s, Memory: %s
+
+There were 2 skipped tests:
+
+1) EliasHaeussler\PHPUnitAttributes\Tests\E2E\RequiresClassAttributeHandlesAutoloadErrorsTest::fakeTest
+Class "Foo\Baz" is required.
+
+2) EliasHaeussler\PHPUnitAttributes\Tests\E2E\RequiresClassAttributeHandlesAutoloadErrorsTest::anotherFakeTest
+Class "Foo\Baz" is required.
+
+OK, but some tests were skipped!
+Tests: 2, Assertions: 0, Skipped: 2.

--- a/tests/e2e/requires-class-attribute/parameter-migration.phpt
+++ b/tests/e2e/requires-class-attribute/parameter-migration.phpt
@@ -43,6 +43,7 @@ Class "Foo\Baz" is required.
 
 %s
 %s
+%s
 
 FAILURES!
 Tests: 2, Assertions: 2, Failures: 1,%sDeprecations: 1.

--- a/tests/e2e/requires-package-attribute/fail-on-unsatisfied-requirement.phpt
+++ b/tests/e2e/requires-package-attribute/fail-on-unsatisfied-requirement.phpt
@@ -29,6 +29,7 @@ Package "foo/baz" is required.
 
 %s
 %s
+%s
 
 FAILURES!
 Tests: 2, Assertions: 2, Failures: 1.

--- a/tests/e2e/requires-package-attribute/fixtures/handle-autoload-errors/phpunit.xml
+++ b/tests/e2e/requires-package-attribute/fixtures/handle-autoload-errors/phpunit.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="../../../../../vendor/phpunit/phpunit/phpunit.xsd"
+>
+    <extensions>
+        <bootstrap class="EliasHaeussler\PHPUnitAttributes\PHPUnitAttributesExtension" />
+    </extensions>
+    <testsuites>
+        <testsuite name="default">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/tests/e2e/requires-package-attribute/fixtures/handle-autoload-errors/tests/RequiresPackageAttributeHandlesAutoloadErrorsTest.php
+++ b/tests/e2e/requires-package-attribute/fixtures/handle-autoload-errors/tests/RequiresPackageAttributeHandlesAutoloadErrorsTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/phpunit-attributes".
+ *
+ * Copyright (C) 2024 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\PHPUnitAttributes\Tests\E2E;
+
+use EliasHaeussler\PHPUnitAttributes as Src;
+use PHPUnit\Framework;
+
+/**
+ * RequiresPackageAttributeHandlesAutoloadErrorsTest.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ */
+#[Src\Attribute\RequiresPackage('foo/baz')]
+final class RequiresPackageAttributeHandlesAutoloadErrorsTest extends Framework\TestCase
+{
+    private Foo $foo;
+
+    protected function setUp(): void
+    {
+        $this->foo = new Foo();
+    }
+
+    #[Framework\Attributes\Test]
+    public function fakeTest(): void
+    {
+        self::assertTrue(true);
+    }
+
+    #[Framework\Attributes\Test]
+    public function anotherFakeTest(): void
+    {
+        self::assertTrue(true);
+    }
+}

--- a/tests/e2e/requires-package-attribute/handle-autoload-errors.phpt
+++ b/tests/e2e/requires-package-attribute/handle-autoload-errors.phpt
@@ -1,0 +1,35 @@
+--TEST--
+Autoload errors in before methods are properly handled
+--FILE--
+<?php
+
+declare(strict_types=1);
+
+$_SERVER['argv'][] = '--do-not-cache-result';
+$_SERVER['argv'][] = '--display-skipped';
+$_SERVER['argv'][] = '--configuration';
+$_SERVER['argv'][] = __DIR__ . '/fixtures/handle-autoload-errors/phpunit.xml';
+
+require dirname(__DIR__, 3) . '/vendor/autoload.php';
+
+(new \PHPUnit\TextUI\Application())->run($_SERVER['argv']);
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+Runtime: %s
+Configuration: %s
+
+SS                                                                  2 / 2 (100%)
+
+Time: %s, Memory: %s
+
+There were 2 skipped tests:
+
+1) EliasHaeussler\PHPUnitAttributes\Tests\E2E\RequiresPackageAttributeHandlesAutoloadErrorsTest::fakeTest
+Package "foo/baz" is required.
+
+2) EliasHaeussler\PHPUnitAttributes\Tests\E2E\RequiresPackageAttributeHandlesAutoloadErrorsTest::anotherFakeTest
+Package "foo/baz" is required.
+
+OK, but some tests were skipped!
+Tests: 2, Assertions: 0, Skipped: 2.

--- a/tests/e2e/requires-package-attribute/parameter-migration.phpt
+++ b/tests/e2e/requires-package-attribute/parameter-migration.phpt
@@ -43,6 +43,7 @@ Package "foo/baz" is required.
 
 %s
 %s
+%s
 
 FAILURES!
 Tests: 2, Assertions: 2, Failures: 1,%sDeprecations: 1.


### PR DESCRIPTION
This PR converts both subscribers to tracers. Tracers can be used the same way as subscribers are used. The difference is that registered tracers are dispatched prior to subscribers. This allows us to handle autoload errors right before PHPUnit's internal subscribers catches them and converts appropriate test statuses to errors.