### PR TITLE
[FEATURE] Introduce `#[RequiresConstant]` attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ be added to the extension registration section like follows:
 The following attributes are shipped with this library:
 
 * [`#[RequiresClass]`](#requiresclass)
+* [`#[RequiresConstant]`](#requiresconstant)
 * [`#[RequiresPackage]`](#requirespackage)
 
 ### [`#[RequiresClass]`](src/Attribute/RequiresClass.php)
@@ -250,6 +251,202 @@ final class DummyTest extends TestCase
     public function testDummyAction(): void
     {
         // Skipped if AnImportantClass and/or AnotherVeryImportantClass are missing.
+    }
+
+    public function testOtherDummyAction(): void
+    {
+        // Not skipped.
+    }
+}
+```
+
+</details>
+
+### [`#[RequiresConstant]`](src/Attribute/RequiresConstant.php)
+
+_Scope: Class & Method level_
+
+With this attribute, tests or test cases can be marked as to be only executed
+if a certain constant exists. The constant can be defined globally or at class
+scope. The latter requires the appropriate class to be loadable by the current
+class loader (which normally is Composer's default class loader).
+
+#### Configuration
+
+By default, test cases requiring undefined constants are skipped. However, this
+behavior can be configured by using the `handleUndefinedConstants` extension
+parameter. If set to `fail`, test cases with undefined constants will fail
+(defaults to `skip`):
+
+```xml
+<extensions>
+    <bootstrap class="EliasHaeussler\PHPUnitAttributes\PHPUnitAttributesExtension">
+        <parameter name="handleUndefinedConstants" value="fail" />
+    </bootstrap>
+</extensions>
+```
+
+#### Example
+
+```php
+final class DummyTest extends TestCase
+{
+    #[RequiresConstant('AN_IMPORTANT_CONSTANT')]
+    public function testDummyAction(): void
+    {
+        // ...
+    }
+}
+```
+
+<details>
+<summary>More examples</summary>
+
+#### Require class constant
+
+Class level:
+
+```php
+#[RequiresConstant(AnImportantClass::class . '::AN_IMPORTANT_CONSTANT')]
+final class DummyTest extends TestCase
+{
+    public function testDummyAction(): void
+    {
+        // Skipped if AnImportantClass::AN_IMPORTANT_CONSTANT is undefined.
+    }
+
+    public function testOtherDummyAction(): void
+    {
+        // Skipped if AnImportantClass::AN_IMPORTANT_CONSTANT is undefined.
+    }
+}
+```
+
+Method level:
+
+```php
+final class DummyTest extends TestCase
+{
+    #[RequiresConstant(AnImportantClass::class . '::AN_IMPORTANT_CONSTANT')]
+    public function testDummyAction(): void
+    {
+        // Skipped if AnImportantClass::AN_IMPORTANT_CONSTANT is undefined.
+    }
+
+    public function testOtherDummyAction(): void
+    {
+        // Not skipped.
+    }
+}
+```
+
+#### Require class constant and provide custom message
+
+Class level:
+
+```php
+#[RequiresConstant(AnImportantClass::class . '::AN_IMPORTANT_CONSTANT', 'This test requires an important constant.')]
+final class DummyTest extends TestCase
+{
+    public function testDummyAction(): void
+    {
+        // Skipped if AnImportantClass::AN_IMPORTANT_CONSTANT is undefined, along with custom message.
+    }
+
+    public function testOtherDummyAction(): void
+    {
+        // Skipped if AnImportantClass::AN_IMPORTANT_CONSTANT is undefined, along with custom message.
+    }
+}
+```
+
+Method level:
+
+```php
+final class DummyTest extends TestCase
+{
+    #[RequiresConstant(AnImportantClass::class . '::AN_IMPORTANT_CONSTANT', 'This test requires an important constant.')]
+    public function testDummyAction(): void
+    {
+        // Skipped if AnImportantClass::AN_IMPORTANT_CONSTANT is undefined, along with custom message.
+    }
+
+    public function testOtherDummyAction(): void
+    {
+        // Not skipped.
+    }
+}
+```
+
+#### Require class constant and define custom outcome behavior
+
+Class level:
+
+```php
+#[RequiresConstant(AnImportantClass::class . '::AN_IMPORTANT_CONSTANT', outcomeBehavior: OutcomeBehavior::Fail)]
+final class DummyTest extends TestCase
+{
+    public function testDummyAction(): void
+    {
+        // Fails if AnImportantClass::AN_IMPORTANT_CONSTANT is undefined.
+    }
+
+    public function testOtherDummyAction(): void
+    {
+        // Fails if AnImportantClass::AN_IMPORTANT_CONSTANT is undefined.
+    }
+}
+```
+
+Method level:
+
+```php
+final class DummyTest extends TestCase
+{
+    #[RequiresConstant(AnImportantClass::class . '::AN_IMPORTANT_CONSTANT', outcomeBehavior: OutcomeBehavior::Fail)]
+    public function testDummyAction(): void
+    {
+        // Fails if AnImportantClass::AN_IMPORTANT_CONSTANT is undefined.
+    }
+
+    public function testOtherDummyAction(): void
+    {
+        // Does not fail.
+    }
+}
+```
+
+#### Require multiple constants
+
+Class level:
+
+```php
+#[RequiresConstant('SOME_IMPORTANT_CONSTANT')]
+#[RequiresConstant('ANOTHER_VERY_IMPORTANT_CONSTANT')]
+final class DummyTest extends TestCase
+{
+    public function testDummyAction(): void
+    {
+        // Skipped if SOME_IMPORTANT_CONSTANT and/or ANOTHER_VERY_IMPORTANT_CONSTANT constants are undefined.
+    }
+
+    public function testOtherDummyAction(): void
+    {
+        // Skipped if SOME_IMPORTANT_CONSTANT and/or ANOTHER_VERY_IMPORTANT_CONSTANT constants are undefined.
+    }
+}
+```
+
+Method level:
+
+```php
+final class DummyTest extends TestCase
+{
+    #[RequiresConstant('SOME_IMPORTANT_CONSTANT')]
+    #[RequiresConstant('ANOTHER_VERY_IMPORTANT_CONSTANT')]
+    public function testDummyAction(): void
+    {
+        // Skipped if SOME_IMPORTANT_CONSTANT and/or ANOTHER_VERY_IMPORTANT_CONSTANT constants are undefined.
     }
 
     public function testOtherDummyAction(): void

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,91 +1,127 @@
 parameters:
 	ignoreErrors:
 		-
-			message: "#^Parameter \\#1 \\$className of attribute class EliasHaeussler\\\\PHPUnitAttributes\\\\Attribute\\\\RequiresClass constructor expects class\\-string, string given\\.$#"
+			message: '#^Parameter \#1 \$className of attribute class EliasHaeussler\\PHPUnitAttributes\\Attribute\\RequiresClass constructor expects class\-string, string given\.$#'
+			identifier: argument.type
 			count: 1
 			path: tests/e2e/requires-class-attribute/fixtures/class-level/tests/RepeatedRequiresClassAttributeTest.php
 
 		-
-			message: "#^Parameter \\#1 \\$className of attribute class EliasHaeussler\\\\PHPUnitAttributes\\\\Attribute\\\\RequiresClass constructor expects class\\-string, string given\\.$#"
+			message: '#^Parameter \#1 \$className of attribute class EliasHaeussler\\PHPUnitAttributes\\Attribute\\RequiresClass constructor expects class\-string, string given\.$#'
+			identifier: argument.type
 			count: 1
 			path: tests/e2e/requires-class-attribute/fixtures/class-level/tests/SingleRequiresClassAttributeTest.php
 
 		-
-			message: "#^Parameter \\#1 \\$className of attribute class EliasHaeussler\\\\PHPUnitAttributes\\\\Attribute\\\\RequiresClass constructor expects class\\-string, string given\\.$#"
+			message: '#^Parameter \#1 \$className of attribute class EliasHaeussler\\PHPUnitAttributes\\Attribute\\RequiresClass constructor expects class\-string, string given\.$#'
+			identifier: argument.type
 			count: 1
 			path: tests/e2e/requires-class-attribute/fixtures/custom-message/tests/RequiresClassAttributeWithCustomMessageTest.php
 
 		-
-			message: "#^Parameter \\#1 \\$className of attribute class EliasHaeussler\\\\PHPUnitAttributes\\\\Attribute\\\\RequiresClass constructor expects class\\-string, string given\\.$#"
+			message: '#^Parameter \#1 \$className of attribute class EliasHaeussler\\PHPUnitAttributes\\Attribute\\RequiresClass constructor expects class\-string, string given\.$#'
+			identifier: argument.type
 			count: 1
 			path: tests/e2e/requires-class-attribute/fixtures/fail-on-unsatisfied-requirement/tests/RequiresClassAttributeFailsOnUnsatisfiedRequirementTest.php
 
 		-
-			message: "#^Instantiated class EliasHaeussler\\\\PHPUnitAttributes\\\\Tests\\\\E2E\\\\Foo not found\\.$#"
+			message: '#^Instantiated class EliasHaeussler\\PHPUnitAttributes\\Tests\\E2E\\Foo not found\.$#'
+			identifier: class.notFound
 			count: 1
 			path: tests/e2e/requires-class-attribute/fixtures/handle-autoload-errors/tests/RequiresClassAttributeHandlesAutoloadErrorsTest.php
 
 		-
-			message: "#^Parameter \\#1 \\$className of attribute class EliasHaeussler\\\\PHPUnitAttributes\\\\Attribute\\\\RequiresClass constructor expects class\\-string, string given\\.$#"
+			message: '#^Parameter \#1 \$className of attribute class EliasHaeussler\\PHPUnitAttributes\\Attribute\\RequiresClass constructor expects class\-string, string given\.$#'
+			identifier: argument.type
 			count: 1
 			path: tests/e2e/requires-class-attribute/fixtures/handle-autoload-errors/tests/RequiresClassAttributeHandlesAutoloadErrorsTest.php
 
 		-
-			message: "#^Property EliasHaeussler\\\\PHPUnitAttributes\\\\Tests\\\\E2E\\\\RequiresClassAttributeHandlesAutoloadErrorsTest\\:\\:\\$foo has unknown class EliasHaeussler\\\\PHPUnitAttributes\\\\Tests\\\\E2E\\\\Foo as its type\\.$#"
+			message: '#^Property EliasHaeussler\\PHPUnitAttributes\\Tests\\E2E\\RequiresClassAttributeHandlesAutoloadErrorsTest\:\:\$foo has unknown class EliasHaeussler\\PHPUnitAttributes\\Tests\\E2E\\Foo as its type\.$#'
+			identifier: class.notFound
 			count: 1
 			path: tests/e2e/requires-class-attribute/fixtures/handle-autoload-errors/tests/RequiresClassAttributeHandlesAutoloadErrorsTest.php
 
 		-
-			message: "#^Property EliasHaeussler\\\\PHPUnitAttributes\\\\Tests\\\\E2E\\\\RequiresClassAttributeHandlesAutoloadErrorsTest\\:\\:\\$foo is never read, only written\\.$#"
+			message: '#^Property EliasHaeussler\\PHPUnitAttributes\\Tests\\E2E\\RequiresClassAttributeHandlesAutoloadErrorsTest\:\:\$foo is never read, only written\.$#'
+			identifier: property.onlyWritten
 			count: 1
 			path: tests/e2e/requires-class-attribute/fixtures/handle-autoload-errors/tests/RequiresClassAttributeHandlesAutoloadErrorsTest.php
 
 		-
-			message: "#^Parameter \\#1 \\$className of attribute class EliasHaeussler\\\\PHPUnitAttributes\\\\Attribute\\\\RequiresClass constructor expects class\\-string, string given\\.$#"
+			message: '#^Parameter \#1 \$className of attribute class EliasHaeussler\\PHPUnitAttributes\\Attribute\\RequiresClass constructor expects class\-string, string given\.$#'
+			identifier: argument.type
 			count: 1
 			path: tests/e2e/requires-class-attribute/fixtures/method-level/tests/RepeatedRequiresClassAttributeTest.php
 
 		-
-			message: "#^Parameter \\#1 \\$className of attribute class EliasHaeussler\\\\PHPUnitAttributes\\\\Attribute\\\\RequiresClass constructor expects class\\-string, string given\\.$#"
+			message: '#^Parameter \#1 \$className of attribute class EliasHaeussler\\PHPUnitAttributes\\Attribute\\RequiresClass constructor expects class\-string, string given\.$#'
+			identifier: argument.type
 			count: 1
 			path: tests/e2e/requires-class-attribute/fixtures/method-level/tests/SingleRequiresClassAttributeTest.php
 
 		-
-			message: "#^Parameter \\#1 \\$className of attribute class EliasHaeussler\\\\PHPUnitAttributes\\\\Attribute\\\\RequiresClass constructor expects class\\-string, string given\\.$#"
+			message: '#^Parameter \#1 \$className of attribute class EliasHaeussler\\PHPUnitAttributes\\Attribute\\RequiresClass constructor expects class\-string, string given\.$#'
+			identifier: argument.type
 			count: 1
 			path: tests/e2e/requires-class-attribute/fixtures/parameter-migration/tests/RequiresClassAttributeFailsWithMigratedParameterTest.php
 
 		-
-			message: "#^Parameter \\#1 \\$className of attribute class EliasHaeussler\\\\PHPUnitAttributes\\\\Attribute\\\\RequiresClass constructor expects class\\-string, string given\\.$#"
+			message: '#^Parameter \#1 \$className of attribute class EliasHaeussler\\PHPUnitAttributes\\Attribute\\RequiresClass constructor expects class\-string, string given\.$#'
+			identifier: argument.type
 			count: 1
 			path: tests/e2e/requires-class-attribute/fixtures/skip-on-invalid-configuration-value/tests/RequiresClassAttributeSkipsOnInvalidConfigurationValueTest.php
 
 		-
-			message: "#^Parameter \\#1 \\$className of attribute class EliasHaeussler\\\\PHPUnitAttributes\\\\Attribute\\\\RequiresClass constructor expects class\\-string, string given\\.$#"
+			message: '#^Parameter \#1 \$className of attribute class EliasHaeussler\\PHPUnitAttributes\\Attribute\\RequiresClass constructor expects class\-string, string given\.$#'
+			identifier: argument.type
 			count: 1
 			path: tests/e2e/requires-class-attribute/fixtures/skip-on-unsatisfied-requirement/tests/RequiresClassAttributeSkipsOnUnsatisfiedRequirementTest.php
 
 		-
-			message: "#^Instantiated class EliasHaeussler\\\\PHPUnitAttributes\\\\Tests\\\\E2E\\\\Foo not found\\.$#"
+			message: '#^Instantiated class EliasHaeussler\\PHPUnitAttributes\\Tests\\E2E\\Foo not found\.$#'
+			identifier: class.notFound
+			count: 1
+			path: tests/e2e/requires-constant-attribute/fixtures/handle-autoload-errors/tests/RequiresConstantAttributeHandlesAutoloadErrorsTest.php
+
+		-
+			message: '#^Property EliasHaeussler\\PHPUnitAttributes\\Tests\\E2E\\RequiresConstantAttributeHandlesAutoloadErrorsTest\:\:\$foo has unknown class EliasHaeussler\\PHPUnitAttributes\\Tests\\E2E\\Foo as its type\.$#'
+			identifier: class.notFound
+			count: 1
+			path: tests/e2e/requires-constant-attribute/fixtures/handle-autoload-errors/tests/RequiresConstantAttributeHandlesAutoloadErrorsTest.php
+
+		-
+			message: '#^Property EliasHaeussler\\PHPUnitAttributes\\Tests\\E2E\\RequiresConstantAttributeHandlesAutoloadErrorsTest\:\:\$foo is never read, only written\.$#'
+			identifier: property.onlyWritten
+			count: 1
+			path: tests/e2e/requires-constant-attribute/fixtures/handle-autoload-errors/tests/RequiresConstantAttributeHandlesAutoloadErrorsTest.php
+
+		-
+			message: '#^Instantiated class EliasHaeussler\\PHPUnitAttributes\\Tests\\E2E\\Foo not found\.$#'
+			identifier: class.notFound
 			count: 1
 			path: tests/e2e/requires-package-attribute/fixtures/handle-autoload-errors/tests/RequiresPackageAttributeHandlesAutoloadErrorsTest.php
 
 		-
-			message: "#^Property EliasHaeussler\\\\PHPUnitAttributes\\\\Tests\\\\E2E\\\\RequiresPackageAttributeHandlesAutoloadErrorsTest\\:\\:\\$foo has unknown class EliasHaeussler\\\\PHPUnitAttributes\\\\Tests\\\\E2E\\\\Foo as its type\\.$#"
+			message: '#^Property EliasHaeussler\\PHPUnitAttributes\\Tests\\E2E\\RequiresPackageAttributeHandlesAutoloadErrorsTest\:\:\$foo has unknown class EliasHaeussler\\PHPUnitAttributes\\Tests\\E2E\\Foo as its type\.$#'
+			identifier: class.notFound
 			count: 1
 			path: tests/e2e/requires-package-attribute/fixtures/handle-autoload-errors/tests/RequiresPackageAttributeHandlesAutoloadErrorsTest.php
 
 		-
-			message: "#^Property EliasHaeussler\\\\PHPUnitAttributes\\\\Tests\\\\E2E\\\\RequiresPackageAttributeHandlesAutoloadErrorsTest\\:\\:\\$foo is never read, only written\\.$#"
+			message: '#^Property EliasHaeussler\\PHPUnitAttributes\\Tests\\E2E\\RequiresPackageAttributeHandlesAutoloadErrorsTest\:\:\$foo is never read, only written\.$#'
+			identifier: property.onlyWritten
 			count: 1
 			path: tests/e2e/requires-package-attribute/fixtures/handle-autoload-errors/tests/RequiresPackageAttributeHandlesAutoloadErrorsTest.php
 
 		-
-			message: "#^Parameter \\#1 \\$className of class EliasHaeussler\\\\PHPUnitAttributes\\\\Attribute\\\\RequiresClass constructor expects class\\-string, string given\\.$#"
+			message: '#^Parameter \#1 \$className of class EliasHaeussler\\PHPUnitAttributes\\Attribute\\RequiresClass constructor expects class\-string, string given\.$#'
+			identifier: argument.type
 			count: 1
 			path: tests/unit/Metadata/ClassRequirementsTest.php
 
 		-
-			message: "#^Parameter \\#1 \\$className of static method EliasHaeussler\\\\PHPUnitAttributes\\\\TextUI\\\\Messages\\:\\:forMissingClass\\(\\) expects class\\-string, string given\\.$#"
+			message: '#^Parameter \#1 \$className of static method EliasHaeussler\\PHPUnitAttributes\\TextUI\\Messages\:\:forMissingClass\(\) expects class\-string, string given\.$#'
+			identifier: argument.type
 			count: 1
 			path: tests/unit/Metadata/ClassRequirementsTest.php

--- a/src/Attribute/RequiresConstant.php
+++ b/src/Attribute/RequiresConstant.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/phpunit-attributes".
+ *
+ * Copyright (C) 2024-2025 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\PHPUnitAttributes\Attribute;
+
+use Attribute;
+use EliasHaeussler\PHPUnitAttributes\Enum;
+
+/**
+ * RequiresConstant.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ */
+#[Attribute(Attribute::TARGET_METHOD | Attribute::TARGET_CLASS | Attribute::IS_REPEATABLE)]
+final class RequiresConstant
+{
+    /**
+     * @param non-empty-string|null $message
+     */
+    public function __construct(
+        private readonly string $constant,
+        private readonly ?string $message = null,
+        private readonly ?Enum\OutcomeBehavior $outcomeBehavior = null,
+    ) {}
+
+    public function constant(): string
+    {
+        return $this->constant;
+    }
+
+    /**
+     * @return non-empty-string|null
+     */
+    public function message(): ?string
+    {
+        return $this->message;
+    }
+
+    public function outcomeBehavior(): ?Enum\OutcomeBehavior
+    {
+        return $this->outcomeBehavior;
+    }
+}

--- a/src/Event/Tracer/RequiresConstantAttributeTracer.php
+++ b/src/Event/Tracer/RequiresConstantAttributeTracer.php
@@ -1,0 +1,153 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/phpunit-attributes".
+ *
+ * Copyright (C) 2024-2025 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\PHPUnitAttributes\Event\Tracer;
+
+use EliasHaeussler\PHPUnitAttributes\Attribute;
+use EliasHaeussler\PHPUnitAttributes\Enum;
+use EliasHaeussler\PHPUnitAttributes\Metadata;
+use EliasHaeussler\PHPUnitAttributes\Reflection;
+use PHPUnit\Event;
+use PHPUnit\Framework;
+
+use function array_filter;
+use function array_keys;
+use function array_values;
+use function implode;
+
+/**
+ * RequiresConstantAttributeTracer.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ */
+final class RequiresConstantAttributeTracer implements Event\Tracer\Tracer
+{
+    /**
+     * @var array<class-string, array<non-empty-string, Enum\OutcomeBehavior>>
+     */
+    private array $testClassBehaviorsCache = [];
+
+    public function __construct(
+        private readonly Metadata\ConstantRequirements $constantRequirements,
+        private readonly Enum\OutcomeBehavior $behaviorOnUndefinedConstants,
+    ) {}
+
+    public function trace(Event\Event $event): void
+    {
+        if ($event instanceof Event\Test\BeforeTestMethodCalled) {
+            $this->processAttributesOnClassLevel($event->testClassName());
+
+            return;
+        }
+
+        if (!($event instanceof Event\Test\Prepared)) {
+            return;
+        }
+
+        $test = $event->test();
+
+        if ($test instanceof Event\Code\TestMethod) {
+            $this->processAttributesOnClassLevel($test->className());
+            $this->processAttributesOnMethodLevel($test->className(), $test->methodName());
+        }
+    }
+
+    /**
+     * @param class-string $testClassName
+     */
+    private function processAttributesOnClassLevel(string $testClassName): void
+    {
+        $behaviors = $this->testClassBehaviorsCache[$testClassName] ?? [];
+
+        if ([] !== $behaviors) {
+            $this->handleOutcomeBehavior($behaviors);
+        }
+
+        $classAttributes = Reflection\AttributeReflector::forClass(
+            $testClassName,
+            Attribute\RequiresConstant::class,
+        );
+        $behaviors = $this->testClassBehaviorsCache[$testClassName] = $this->checkConstants($classAttributes);
+
+        if ([] !== $behaviors) {
+            $this->handleOutcomeBehavior($behaviors);
+        }
+    }
+
+    /**
+     * @param class-string $testClassName
+     */
+    private function processAttributesOnMethodLevel(string $testClassName, string $testMethodName): void
+    {
+        $methodAttributes = Reflection\AttributeReflector::forClassMethod(
+            $testClassName,
+            $testMethodName,
+            Attribute\RequiresConstant::class,
+        );
+        $behaviors = $this->checkConstants($methodAttributes);
+
+        if ([] !== $behaviors) {
+            $this->handleOutcomeBehavior($behaviors);
+        }
+    }
+
+    /**
+     * @param list<Attribute\RequiresConstant> $attributes
+     *
+     * @return array<non-empty-string, Enum\OutcomeBehavior>
+     */
+    private function checkConstants(array $attributes): array
+    {
+        $notSatisfied = [];
+
+        foreach ($attributes as $attribute) {
+            $message = $this->constantRequirements->validateForAttribute($attribute);
+
+            if (null !== $message) {
+                $notSatisfied[$message] = $attribute->outcomeBehavior() ?? $this->behaviorOnUndefinedConstants;
+            }
+        }
+
+        return $notSatisfied;
+    }
+
+    /**
+     * @param array<non-empty-string, Enum\OutcomeBehavior> $behaviors
+     */
+    private function handleOutcomeBehavior(array $behaviors): never
+    {
+        $message = implode(PHP_EOL, array_keys($behaviors));
+        $outcomeBehaviors = array_values(
+            array_filter(
+                $behaviors,
+                static fn (?Enum\OutcomeBehavior $outcomeBehavior) => null !== $outcomeBehavior,
+            ),
+        );
+
+        match (Enum\OutcomeBehavior::fromSet($outcomeBehaviors) ?? $this->behaviorOnUndefinedConstants) {
+            Enum\OutcomeBehavior::Fail => Framework\Assert::fail($message),
+            Enum\OutcomeBehavior::Skip => Framework\Assert::markTestSkipped($message),
+        };
+    }
+}

--- a/src/Metadata/ConstantRequirements.php
+++ b/src/Metadata/ConstantRequirements.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/phpunit-attributes".
+ *
+ * Copyright (C) 2024-2025 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\PHPUnitAttributes\Metadata;
+
+use EliasHaeussler\PHPUnitAttributes\Attribute;
+use EliasHaeussler\PHPUnitAttributes\TextUI;
+
+use function defined;
+
+/**
+ * ConstantRequirements.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ */
+final class ConstantRequirements
+{
+    /**
+     * @return non-empty-string|null
+     */
+    public function validateForAttribute(Attribute\RequiresConstant $attribute): ?string
+    {
+        $constant = $attribute->constant();
+        $message = $attribute->message();
+
+        if (!@defined($constant)) {
+            return $message ?? TextUI\Messages::forUndefinedConstant($constant);
+        }
+
+        return null;
+    }
+}

--- a/src/PHPUnitAttributesExtension.php
+++ b/src/PHPUnitAttributesExtension.php
@@ -58,6 +58,19 @@ final class PHPUnitAttributesExtension implements Runner\Extension\Extension
             ),
         );
 
+        if ($parameters->has('handleUndefinedConstants')) {
+            $handleUndefinedConstants = Enum\OutcomeBehavior::tryFrom($parameters->get('handleUndefinedConstants'));
+        } else {
+            $handleUndefinedConstants = null;
+        }
+
+        $facade->registerTracer(
+            new Event\Tracer\RequiresConstantAttributeTracer(
+                new Metadata\ConstantRequirements(),
+                $handleUndefinedConstants ?? Enum\OutcomeBehavior::Skip,
+            ),
+        );
+
         $this->triggerDeprecationForMigratedConfigurationParameters(
             $configuration->colors(),
             $requiresPackageMigrationResult,

--- a/src/TextUI/Messages.php
+++ b/src/TextUI/Messages.php
@@ -62,4 +62,12 @@ final class Messages
     {
         return sprintf('Class "%s" is required.', $className);
     }
+
+    /**
+     * @return non-empty-string
+     */
+    public static function forUndefinedConstant(string $constant): string
+    {
+        return sprintf('Constant "%s" is required.', $constant);
+    }
 }

--- a/tests/e2e/requires-constant-attribute/class-level.phpt
+++ b/tests/e2e/requires-constant-attribute/class-level.phpt
@@ -1,0 +1,41 @@
+--TEST--
+The #[RequiresConstant] attribute is applied on class level
+--FILE--
+<?php
+
+declare(strict_types=1);
+
+$_SERVER['argv'][] = '--do-not-cache-result';
+$_SERVER['argv'][] = '--display-skipped';
+$_SERVER['argv'][] = '--configuration';
+$_SERVER['argv'][] = __DIR__ . '/fixtures/class-level/phpunit.xml';
+
+require dirname(__DIR__, 3) . '/vendor/autoload.php';
+
+(new \PHPUnit\TextUI\Application())->run($_SERVER['argv']);
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+Runtime: %s
+Configuration: %s
+
+SSSS                                                                4 / 4 (100%)
+
+Time: %s, Memory: %s
+
+There were 4 skipped tests:
+
+1) EliasHaeussler\PHPUnitAttributes\Tests\E2E\RepeatedRequiresConstantAttributeTest::fakeTest
+Constant "FOO_BAZ_BAR" is required.
+
+2) EliasHaeussler\PHPUnitAttributes\Tests\E2E\RepeatedRequiresConstantAttributeTest::anotherFakeTest
+Constant "FOO_BAZ_BAR" is required.
+
+3) EliasHaeussler\PHPUnitAttributes\Tests\E2E\SingleRequiresConstantAttributeTest::fakeTest
+Constant "FOO_BAZ" is required.
+
+4) EliasHaeussler\PHPUnitAttributes\Tests\E2E\SingleRequiresConstantAttributeTest::anotherFakeTest
+Constant "FOO_BAZ" is required.
+
+OK, but some tests were skipped!
+Tests: 4, Assertions: 0, Skipped: 4.

--- a/tests/e2e/requires-constant-attribute/custom-message.phpt
+++ b/tests/e2e/requires-constant-attribute/custom-message.phpt
@@ -1,0 +1,32 @@
+--TEST--
+The #[RequiresConstant] attribute is applied with custom message
+--FILE--
+<?php
+
+declare(strict_types=1);
+
+$_SERVER['argv'][] = '--do-not-cache-result';
+$_SERVER['argv'][] = '--display-skipped';
+$_SERVER['argv'][] = '--configuration';
+$_SERVER['argv'][] = __DIR__ . '/fixtures/custom-message/phpunit.xml';
+
+require dirname(__DIR__, 3) . '/vendor/autoload.php';
+
+(new \PHPUnit\TextUI\Application())->run($_SERVER['argv']);
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+Runtime: %s
+Configuration: %s
+
+S                                                                   1 / 1 (100%)
+
+Time: %s, Memory: %s
+
+There was 1 skipped test:
+
+1) EliasHaeussler\PHPUnitAttributes\Tests\E2E\RequiresConstantAttributeWithCustomMessageTest::fakeTest
+You're obviously missing some FOO...
+
+OK, but some tests were skipped!
+Tests: 1, Assertions: 0, Skipped: 1.

--- a/tests/e2e/requires-constant-attribute/fail-on-unsatisfied-requirement.phpt
+++ b/tests/e2e/requires-constant-attribute/fail-on-unsatisfied-requirement.phpt
@@ -1,0 +1,35 @@
+--TEST--
+The #[RequiresConstant] attribute causes tests with unsatisified requirement to fail
+--FILE--
+<?php
+
+declare(strict_types=1);
+
+$_SERVER['argv'][] = '--do-not-cache-result';
+$_SERVER['argv'][] = '--configuration';
+$_SERVER['argv'][] = __DIR__ . '/fixtures/fail-on-unsatisfied-requirement/phpunit.xml';
+
+require dirname(__DIR__, 3) . '/vendor/autoload.php';
+
+(new \PHPUnit\TextUI\Application())->run($_SERVER['argv']);
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+Runtime: %s
+Configuration: %s
+
+F.                                                                  2 / 2 (100%)
+
+Time: %s, Memory: %s
+
+There was 1 failure:
+
+1) EliasHaeussler\PHPUnitAttributes\Tests\E2E\RequiresConstantAttributeFailsOnUnsatisfiedRequirementTest::fakeTest
+Constant "FOO_BAZ" is required.
+
+%s
+%s
+%s
+
+FAILURES!
+Tests: 2, Assertions: 2, Failures: 1.

--- a/tests/e2e/requires-constant-attribute/fixtures/class-level/phpunit.xml
+++ b/tests/e2e/requires-constant-attribute/fixtures/class-level/phpunit.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="../../../../../vendor/phpunit/phpunit/phpunit.xsd"
+>
+    <extensions>
+        <bootstrap class="EliasHaeussler\PHPUnitAttributes\PHPUnitAttributesExtension" />
+    </extensions>
+    <testsuites>
+        <testsuite name="default">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/tests/e2e/requires-constant-attribute/fixtures/class-level/tests/RepeatedRequiresConstantAttributeTest.php
+++ b/tests/e2e/requires-constant-attribute/fixtures/class-level/tests/RepeatedRequiresConstantAttributeTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/phpunit-attributes".
+ *
+ * Copyright (C) 2024-2025 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\PHPUnitAttributes\Tests\E2E;
+
+use EliasHaeussler\PHPUnitAttributes as Src;
+use PHPUnit\Framework;
+
+/**
+ * RepeatedRequiresConstantAttributeTest.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ */
+#[Src\Attribute\RequiresConstant('PHP_VERSION')]
+#[Src\Attribute\RequiresConstant('FOO_BAZ_BAR')]
+final class RepeatedRequiresConstantAttributeTest extends Framework\TestCase
+{
+    #[Framework\Attributes\Test]
+    public function fakeTest(): void
+    {
+        self::assertTrue(true);
+    }
+
+    #[Framework\Attributes\Test]
+    public function anotherFakeTest(): void
+    {
+        self::assertTrue(true);
+    }
+}

--- a/tests/e2e/requires-constant-attribute/fixtures/class-level/tests/SingleRequiresConstantAttributeTest.php
+++ b/tests/e2e/requires-constant-attribute/fixtures/class-level/tests/SingleRequiresConstantAttributeTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/phpunit-attributes".
+ *
+ * Copyright (C) 2024-2025 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\PHPUnitAttributes\Tests\E2E;
+
+use EliasHaeussler\PHPUnitAttributes as Src;
+use PHPUnit\Framework;
+
+/**
+ * SingleRequiresConstantAttributeTest.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ */
+#[Src\Attribute\RequiresConstant('FOO_BAZ')]
+final class SingleRequiresConstantAttributeTest extends Framework\TestCase
+{
+    #[Framework\Attributes\Test]
+    public function fakeTest(): void
+    {
+        self::assertTrue(true);
+    }
+
+    #[Framework\Attributes\Test]
+    public function anotherFakeTest(): void
+    {
+        self::assertTrue(true);
+    }
+}

--- a/tests/e2e/requires-constant-attribute/fixtures/custom-message/phpunit.xml
+++ b/tests/e2e/requires-constant-attribute/fixtures/custom-message/phpunit.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="../../../../../vendor/phpunit/phpunit/phpunit.xsd"
+>
+    <extensions>
+        <bootstrap class="EliasHaeussler\PHPUnitAttributes\PHPUnitAttributesExtension" />
+    </extensions>
+    <testsuites>
+        <testsuite name="default">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/tests/e2e/requires-constant-attribute/fixtures/custom-message/tests/RequiresConstantAttributeWithCustomMessageTest.php
+++ b/tests/e2e/requires-constant-attribute/fixtures/custom-message/tests/RequiresConstantAttributeWithCustomMessageTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/phpunit-attributes".
+ *
+ * Copyright (C) 2024-2025 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\PHPUnitAttributes\Tests\E2E;
+
+use EliasHaeussler\PHPUnitAttributes as Src;
+use PHPUnit\Framework;
+
+/**
+ * RequiresConstantAttributeWithCustomMessageTest.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ */
+final class RequiresConstantAttributeWithCustomMessageTest extends Framework\TestCase
+{
+    #[Framework\Attributes\Test]
+    #[Src\Attribute\RequiresConstant('FOO_BAZ', 'You\'re obviously missing some FOO...')]
+    public function fakeTest(): void
+    {
+        self::assertTrue(true);
+    }
+}

--- a/tests/e2e/requires-constant-attribute/fixtures/fail-on-unsatisfied-requirement/phpunit.xml
+++ b/tests/e2e/requires-constant-attribute/fixtures/fail-on-unsatisfied-requirement/phpunit.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="../../../../../vendor/phpunit/phpunit/phpunit.xsd"
+>
+    <extensions>
+        <bootstrap class="EliasHaeussler\PHPUnitAttributes\PHPUnitAttributesExtension">
+            <parameter name="handleUndefinedConstants" value="fail" />
+        </bootstrap>
+    </extensions>
+    <testsuites>
+        <testsuite name="default">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/tests/e2e/requires-constant-attribute/fixtures/fail-on-unsatisfied-requirement/tests/RequiresConstantAttributeFailsOnUnsatisfiedRequirementTest.php
+++ b/tests/e2e/requires-constant-attribute/fixtures/fail-on-unsatisfied-requirement/tests/RequiresConstantAttributeFailsOnUnsatisfiedRequirementTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/phpunit-attributes".
+ *
+ * Copyright (C) 2024-2025 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\PHPUnitAttributes\Tests\E2E;
+
+use EliasHaeussler\PHPUnitAttributes as Src;
+use PHPUnit\Framework;
+
+/**
+ * RequiresConstantAttributeFailsOnUnsatisfiedRequirementTest.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ */
+final class RequiresConstantAttributeFailsOnUnsatisfiedRequirementTest extends Framework\TestCase
+{
+    #[Framework\Attributes\Test]
+    #[Src\Attribute\RequiresConstant('FOO_BAZ')]
+    public function fakeTest(): void
+    {
+        self::assertTrue(true);
+    }
+
+    #[Framework\Attributes\Test]
+    public function anotherFakeTest(): void
+    {
+        self::assertTrue(true);
+    }
+}

--- a/tests/e2e/requires-constant-attribute/fixtures/handle-autoload-errors/phpunit.xml
+++ b/tests/e2e/requires-constant-attribute/fixtures/handle-autoload-errors/phpunit.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="../../../../../vendor/phpunit/phpunit/phpunit.xsd"
+>
+    <extensions>
+        <bootstrap class="EliasHaeussler\PHPUnitAttributes\PHPUnitAttributesExtension" />
+    </extensions>
+    <testsuites>
+        <testsuite name="default">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/tests/e2e/requires-constant-attribute/fixtures/handle-autoload-errors/tests/RequiresConstantAttributeHandlesAutoloadErrorsTest.php
+++ b/tests/e2e/requires-constant-attribute/fixtures/handle-autoload-errors/tests/RequiresConstantAttributeHandlesAutoloadErrorsTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/phpunit-attributes".
+ *
+ * Copyright (C) 2024-2025 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\PHPUnitAttributes\Tests\E2E;
+
+use EliasHaeussler\PHPUnitAttributes as Src;
+use PHPUnit\Framework;
+
+/**
+ * RequiresConstantAttributeHandlesAutoloadErrorsTest.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ */
+#[Src\Attribute\RequiresConstant('FOO_BAZ')]
+final class RequiresConstantAttributeHandlesAutoloadErrorsTest extends Framework\TestCase
+{
+    private Foo $foo;
+
+    protected function setUp(): void
+    {
+        $this->foo = new Foo();
+    }
+
+    #[Framework\Attributes\Test]
+    public function fakeTest(): void
+    {
+        self::assertTrue(true);
+    }
+
+    #[Framework\Attributes\Test]
+    public function anotherFakeTest(): void
+    {
+        self::assertTrue(true);
+    }
+}

--- a/tests/e2e/requires-constant-attribute/fixtures/ignore-phpt-tests/phpunit.dummy.xml
+++ b/tests/e2e/requires-constant-attribute/fixtures/ignore-phpt-tests/phpunit.dummy.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="../../../../../vendor/phpunit/phpunit/phpunit.xsd"
+>
+    <extensions>
+        <bootstrap class="EliasHaeussler\PHPUnitAttributes\PHPUnitAttributesExtension" />
+    </extensions>
+    <testsuites>
+        <testsuite name="default">
+            <directory suffix=".php">tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/tests/e2e/requires-constant-attribute/fixtures/ignore-phpt-tests/phpunit.xml
+++ b/tests/e2e/requires-constant-attribute/fixtures/ignore-phpt-tests/phpunit.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="../../../../../vendor/phpunit/phpunit/phpunit.xsd"
+>
+    <extensions>
+        <bootstrap class="EliasHaeussler\PHPUnitAttributes\PHPUnitAttributesExtension" />
+    </extensions>
+    <testsuites>
+        <testsuite name="default">
+            <directory suffix=".phpt">tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/tests/e2e/requires-constant-attribute/fixtures/ignore-phpt-tests/tests/DummyTest.php
+++ b/tests/e2e/requires-constant-attribute/fixtures/ignore-phpt-tests/tests/DummyTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/phpunit-attributes".
+ *
+ * Copyright (C) 2024-2025 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\PHPUnitAttributes\Tests\E2E;
+
+use PHPUnit\Framework;
+
+/**
+ * DummyTest.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ */
+final class DummyTest extends Framework\TestCase
+{
+    #[Framework\Attributes\Test]
+    public function fakeTest(): void
+    {
+        self::assertTrue(true);
+    }
+}

--- a/tests/e2e/requires-constant-attribute/fixtures/ignore-phpt-tests/tests/dummy-test.phpt
+++ b/tests/e2e/requires-constant-attribute/fixtures/ignore-phpt-tests/tests/dummy-test.phpt
@@ -1,0 +1,25 @@
+--TEST--
+This is just a dummy test
+--FILE--
+<?php
+
+declare(strict_types=1);
+
+$_SERVER['argv'][] = '--do-not-cache-result';
+$_SERVER['argv'][] = '--configuration';
+$_SERVER['argv'][] = dirname(__DIR__) . '/phpunit.dummy.xml';
+
+require dirname(__DIR__, 6) . '/vendor/autoload.php';
+
+(new \PHPUnit\TextUI\Application())->run($_SERVER['argv']);
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+Runtime: %s
+Configuration: %s
+
+.                                                                   1 / 1 (100%)
+
+Time: %s, Memory: %s
+
+OK (1 test, 1 assertion)

--- a/tests/e2e/requires-constant-attribute/fixtures/method-level/phpunit.xml
+++ b/tests/e2e/requires-constant-attribute/fixtures/method-level/phpunit.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="../../../../../vendor/phpunit/phpunit/phpunit.xsd"
+>
+    <extensions>
+        <bootstrap class="EliasHaeussler\PHPUnitAttributes\PHPUnitAttributesExtension" />
+    </extensions>
+    <testsuites>
+        <testsuite name="default">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/tests/e2e/requires-constant-attribute/fixtures/method-level/tests/RepeatedRequiresConstantAttributeTest.php
+++ b/tests/e2e/requires-constant-attribute/fixtures/method-level/tests/RepeatedRequiresConstantAttributeTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/phpunit-attributes".
+ *
+ * Copyright (C) 2024-2025 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\PHPUnitAttributes\Tests\E2E;
+
+use EliasHaeussler\PHPUnitAttributes as Src;
+use PHPUnit\Framework;
+
+/**
+ * RepeatedRequiresConstantAttributeTest.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ */
+final class RepeatedRequiresConstantAttributeTest extends Framework\TestCase
+{
+    #[Framework\Attributes\Test]
+    #[Src\Attribute\RequiresConstant('PHP_VERSION')]
+    #[Src\Attribute\RequiresConstant('FOO_BAZ_BAR')]
+    public function fakeTest(): void
+    {
+        self::assertTrue(true);
+    }
+
+    #[Framework\Attributes\Test]
+    public function anotherFakeTest(): void
+    {
+        self::assertTrue(true);
+    }
+}

--- a/tests/e2e/requires-constant-attribute/fixtures/method-level/tests/SingleRequiresConstantAttributeTest.php
+++ b/tests/e2e/requires-constant-attribute/fixtures/method-level/tests/SingleRequiresConstantAttributeTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/phpunit-attributes".
+ *
+ * Copyright (C) 2024-2025 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\PHPUnitAttributes\Tests\E2E;
+
+use EliasHaeussler\PHPUnitAttributes as Src;
+use PHPUnit\Framework;
+
+/**
+ * SingleRequiresConstantAttributeTest.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ */
+final class SingleRequiresConstantAttributeTest extends Framework\TestCase
+{
+    #[Framework\Attributes\Test]
+    #[Src\Attribute\RequiresConstant('FOO_BAZ')]
+    public function fakeTest(): void
+    {
+        self::assertTrue(true);
+    }
+
+    #[Framework\Attributes\Test]
+    public function anotherFakeTest(): void
+    {
+        self::assertTrue(true);
+    }
+}

--- a/tests/e2e/requires-constant-attribute/fixtures/skip-on-invalid-configuration-value/phpunit.xml
+++ b/tests/e2e/requires-constant-attribute/fixtures/skip-on-invalid-configuration-value/phpunit.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="../../../../../vendor/phpunit/phpunit/phpunit.xsd"
+>
+    <extensions>
+        <bootstrap class="EliasHaeussler\PHPUnitAttributes\PHPUnitAttributesExtension">
+            <!-- "foo" is invalid here by purpose, test verifies that it's normalized to ”skip" -->
+            <parameter name="handleUndefinedConstants" value="foo" />
+        </bootstrap>
+    </extensions>
+    <testsuites>
+        <testsuite name="default">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/tests/e2e/requires-constant-attribute/fixtures/skip-on-invalid-configuration-value/tests/RequiresConstantAttributeSkipsOnInvalidConfigurationValueTest.php
+++ b/tests/e2e/requires-constant-attribute/fixtures/skip-on-invalid-configuration-value/tests/RequiresConstantAttributeSkipsOnInvalidConfigurationValueTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/phpunit-attributes".
+ *
+ * Copyright (C) 2024-2025 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\PHPUnitAttributes\Tests\E2E;
+
+use EliasHaeussler\PHPUnitAttributes as Src;
+use PHPUnit\Framework;
+
+/**
+ * RequiresConstantAttributeSkipsOnInvalidConfigurationValueTest.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ */
+final class RequiresConstantAttributeSkipsOnInvalidConfigurationValueTest extends Framework\TestCase
+{
+    #[Framework\Attributes\Test]
+    #[Src\Attribute\RequiresConstant('FOO_BAZ')]
+    public function fakeTest(): void
+    {
+        self::assertTrue(true);
+    }
+
+    #[Framework\Attributes\Test]
+    public function anotherFakeTest(): void
+    {
+        self::assertTrue(true);
+    }
+}

--- a/tests/e2e/requires-constant-attribute/fixtures/skip-on-unsatisfied-requirement/phpunit.xml
+++ b/tests/e2e/requires-constant-attribute/fixtures/skip-on-unsatisfied-requirement/phpunit.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="../../../../../vendor/phpunit/phpunit/phpunit.xsd"
+>
+    <extensions>
+        <bootstrap class="EliasHaeussler\PHPUnitAttributes\PHPUnitAttributesExtension">
+            <parameter name="handleUndefinedConstants" value="skip" />
+        </bootstrap>
+    </extensions>
+    <testsuites>
+        <testsuite name="default">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/tests/e2e/requires-constant-attribute/fixtures/skip-on-unsatisfied-requirement/tests/RequiresConstantAttributeSkipsOnUnsatisfiedRequirementTest.php
+++ b/tests/e2e/requires-constant-attribute/fixtures/skip-on-unsatisfied-requirement/tests/RequiresConstantAttributeSkipsOnUnsatisfiedRequirementTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/phpunit-attributes".
+ *
+ * Copyright (C) 2024-2025 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\PHPUnitAttributes\Tests\E2E;
+
+use EliasHaeussler\PHPUnitAttributes as Src;
+use PHPUnit\Framework;
+
+/**
+ * RequiresConstantAttributeSkipsOnUnsatisfiedRequirementTest.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ */
+final class RequiresConstantAttributeSkipsOnUnsatisfiedRequirementTest extends Framework\TestCase
+{
+    #[Framework\Attributes\Test]
+    #[Src\Attribute\RequiresConstant('FOO_BAZ')]
+    public function fakeTest(): void
+    {
+        self::assertTrue(true);
+    }
+
+    #[Framework\Attributes\Test]
+    public function anotherFakeTest(): void
+    {
+        self::assertTrue(true);
+    }
+}

--- a/tests/e2e/requires-constant-attribute/handle-autoload-errors.phpt
+++ b/tests/e2e/requires-constant-attribute/handle-autoload-errors.phpt
@@ -1,0 +1,35 @@
+--TEST--
+Autoload errors in before methods are properly handled
+--FILE--
+<?php
+
+declare(strict_types=1);
+
+$_SERVER['argv'][] = '--do-not-cache-result';
+$_SERVER['argv'][] = '--display-skipped';
+$_SERVER['argv'][] = '--configuration';
+$_SERVER['argv'][] = __DIR__ . '/fixtures/handle-autoload-errors/phpunit.xml';
+
+require dirname(__DIR__, 3) . '/vendor/autoload.php';
+
+(new \PHPUnit\TextUI\Application())->run($_SERVER['argv']);
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+Runtime: %s
+Configuration: %s
+
+SS                                                                  2 / 2 (100%)
+
+Time: %s, Memory: %s
+
+There were 2 skipped tests:
+
+1) EliasHaeussler\PHPUnitAttributes\Tests\E2E\RequiresConstantAttributeHandlesAutoloadErrorsTest::fakeTest
+Constant "FOO_BAZ" is required.
+
+2) EliasHaeussler\PHPUnitAttributes\Tests\E2E\RequiresConstantAttributeHandlesAutoloadErrorsTest::anotherFakeTest
+Constant "FOO_BAZ" is required.
+
+OK, but some tests were skipped!
+Tests: 2, Assertions: 0, Skipped: 2.

--- a/tests/e2e/requires-constant-attribute/ignore-phpt-tests.phpt
+++ b/tests/e2e/requires-constant-attribute/ignore-phpt-tests.phpt
@@ -1,0 +1,25 @@
+--TEST--
+The RequiresConstantAttributeSubscriber skips PHPT tests
+--FILE--
+<?php
+
+declare(strict_types=1);
+
+$_SERVER['argv'][] = '--do-not-cache-result';
+$_SERVER['argv'][] = '--configuration';
+$_SERVER['argv'][] = __DIR__ . '/fixtures/ignore-phpt-tests/phpunit.xml';
+
+require dirname(__DIR__, 3) . '/vendor/autoload.php';
+
+(new \PHPUnit\TextUI\Application())->run($_SERVER['argv']);
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+Runtime: %s
+Configuration: %s
+
+.                                                                   1 / 1 (100%)
+
+Time: %s, Memory: %s
+
+OK (1 test, 1 assertion)

--- a/tests/e2e/requires-constant-attribute/method-level.phpt
+++ b/tests/e2e/requires-constant-attribute/method-level.phpt
@@ -1,0 +1,35 @@
+--TEST--
+The #[RequiresConstant] attribute is applied on method level
+--FILE--
+<?php
+
+declare(strict_types=1);
+
+$_SERVER['argv'][] = '--do-not-cache-result';
+$_SERVER['argv'][] = '--display-skipped';
+$_SERVER['argv'][] = '--configuration';
+$_SERVER['argv'][] = __DIR__ . '/fixtures/method-level/phpunit.xml';
+
+require dirname(__DIR__, 3) . '/vendor/autoload.php';
+
+(new \PHPUnit\TextUI\Application())->run($_SERVER['argv']);
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+Runtime: %s
+Configuration: %s
+
+S.S.                                                                4 / 4 (100%)
+
+Time: %s, Memory: %s
+
+There were 2 skipped tests:
+
+1) EliasHaeussler\PHPUnitAttributes\Tests\E2E\RepeatedRequiresConstantAttributeTest::fakeTest
+Constant "FOO_BAZ_BAR" is required.
+
+2) EliasHaeussler\PHPUnitAttributes\Tests\E2E\SingleRequiresConstantAttributeTest::fakeTest
+Constant "FOO_BAZ" is required.
+
+OK, but some tests were skipped!
+Tests: 4, Assertions: 2, Skipped: 2.

--- a/tests/e2e/requires-constant-attribute/skip-on-invalid-configuration-value.phpt
+++ b/tests/e2e/requires-constant-attribute/skip-on-invalid-configuration-value.phpt
@@ -1,0 +1,32 @@
+--TEST--
+Invalid configuration options are normalized to tests with unsatisfied requirements being skipped
+--FILE--
+<?php
+
+declare(strict_types=1);
+
+$_SERVER['argv'][] = '--do-not-cache-result';
+$_SERVER['argv'][] = '--display-skipped';
+$_SERVER['argv'][] = '--configuration';
+$_SERVER['argv'][] = __DIR__ . '/fixtures/skip-on-invalid-configuration-value/phpunit.xml';
+
+require dirname(__DIR__, 3) . '/vendor/autoload.php';
+
+(new \PHPUnit\TextUI\Application())->run($_SERVER['argv']);
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+Runtime: %s
+Configuration: %s
+
+S.                                                                  2 / 2 (100%)
+
+Time: %s, Memory: %s
+
+There was 1 skipped test:
+
+1) EliasHaeussler\PHPUnitAttributes\Tests\E2E\RequiresConstantAttributeSkipsOnInvalidConfigurationValueTest::fakeTest
+Constant "FOO_BAZ" is required.
+
+OK, but some tests were skipped!
+Tests: 2, Assertions: 1, Skipped: 1.

--- a/tests/e2e/requires-constant-attribute/skip-on-unsatisfied-requirement.phpt
+++ b/tests/e2e/requires-constant-attribute/skip-on-unsatisfied-requirement.phpt
@@ -1,0 +1,32 @@
+--TEST--
+The #[RequiresConstant] attribute causes tests with unsatisified requirement to be skipped
+--FILE--
+<?php
+
+declare(strict_types=1);
+
+$_SERVER['argv'][] = '--do-not-cache-result';
+$_SERVER['argv'][] = '--display-skipped';
+$_SERVER['argv'][] = '--configuration';
+$_SERVER['argv'][] = __DIR__ . '/fixtures/skip-on-unsatisfied-requirement/phpunit.xml';
+
+require dirname(__DIR__, 3) . '/vendor/autoload.php';
+
+(new \PHPUnit\TextUI\Application())->run($_SERVER['argv']);
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+Runtime: %s
+Configuration: %s
+
+S.                                                                  2 / 2 (100%)
+
+Time: %s, Memory: %s
+
+There was 1 skipped test:
+
+1) EliasHaeussler\PHPUnitAttributes\Tests\E2E\RequiresConstantAttributeSkipsOnUnsatisfiedRequirementTest::fakeTest
+Constant "FOO_BAZ" is required.
+
+OK, but some tests were skipped!
+Tests: 2, Assertions: 1, Skipped: 1.

--- a/tests/unit/Metadata/ConstantRequirementsTest.php
+++ b/tests/unit/Metadata/ConstantRequirementsTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/phpunit-attributes".
+ *
+ * Copyright (C) 2024-2025 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\PHPUnitAttributes\Tests\Metadata;
+
+use EliasHaeussler\PHPUnitAttributes as Src;
+use Generator;
+use PHPUnit\Framework;
+
+/**
+ * ConstantRequirementsTest.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ */
+#[Framework\Attributes\CoversClass(Src\Metadata\ConstantRequirements::class)]
+final class ConstantRequirementsTest extends Framework\TestCase
+{
+    private Src\Metadata\ConstantRequirements $subject;
+
+    public function setUp(): void
+    {
+        $this->subject = new Src\Metadata\ConstantRequirements();
+    }
+
+    /**
+     * @param non-empty-string|null $message
+     */
+    #[Framework\Attributes\Test]
+    #[Framework\Attributes\DataProvider('validateForAttributeReturnsMessageIfConstantIsUndefinedDataProvider')]
+    public function validateForAttributeReturnsMessageIfConstantIsUndefined(?string $message, string $expected): void
+    {
+        $attribute = new Src\Attribute\RequiresConstant('FOO_BAZ', $message);
+
+        self::assertSame($expected, $this->subject->validateForAttribute($attribute));
+    }
+
+    #[Framework\Attributes\Test]
+    public function validateForAttributeReturnsNullIfConstantIsDefined(): void
+    {
+        $attribute = new Src\Attribute\RequiresConstant('PHP_VERSION');
+
+        self::assertNull($this->subject->validateForAttribute($attribute));
+    }
+
+    /**
+     * @return Generator<string, array{non-empty-string|null, non-empty-string}>
+     */
+    public static function validateForAttributeReturnsMessageIfConstantIsUndefinedDataProvider(): Generator
+    {
+        yield 'no message' => [null, Src\TextUI\Messages::forUndefinedConstant('FOO_BAZ')];
+        yield 'custom message' => ['FOO_BAZ is undefined, sorry!', 'FOO_BAZ is undefined, sorry!'];
+    }
+}


### PR DESCRIPTION
This pull request introduces a new attribute `#[RequiresConstant]` and updates the documentation, configuration, and codebase to support this new feature. The most important changes include adding the new attribute and its associated functionality, updating the documentation, and modifying the configuration file to handle new error cases.

### New Attribute and Functionality:

* [`src/Attribute/RequiresConstant.php`](diffhunk://#diff-4ca9a957c2f0675f10b40e9136b446319470da599e19ea6b882da543f2e5db91R1-R64): Added the new `#[RequiresConstant]` attribute to mark tests or test cases that should only be executed if a certain constant exists. This attribute can be applied at both class and method levels.
* [`src/Event/Tracer/RequiresConstantAttributeTracer.php`](diffhunk://#diff-d327e35846986b28cb9647c70bc505cf2bd4dbd6b6ce715ca3eb65b0c0c31840R1-R153): Implemented a tracer for the `#[RequiresConstant]` attribute to handle the outcome behavior when the required constant is not defined.
* [`src/Metadata/ConstantRequirements.php`](diffhunk://#diff-f9bd4d916ae22305c33fc1e6684f9c4f2c8cb4b7805ba7c1daab77ce1650290cR1-R53): Added a class to validate the presence of constants required by the `#[RequiresConstant]` attribute.

### Documentation Updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R68): Updated to include details about the `#[RequiresConstant]` attribute, its scope, configuration, and examples of usage at both class and method levels. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R68) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R265-R460)

### Configuration Updates:

* [`phpstan-baseline.neon`](diffhunk://#diff-995edee38ad4f8387e58ebd52c31bcc04c56cc2448d331b1cf5e0b35c57b9efaL4-R125): Modified to include new error identifiers and messages related to the `#[RequiresConstant]` attribute, ensuring proper handling of undefined constants in tests.

### Additional Code Changes:

* [`src/PHPUnitAttributesExtension.php`](diffhunk://#diff-7ad5f081b769fd33686cdf5b7f6ebd387b50914a4748ad2829bf3945a299f185R61-R73): Updated to register the new `RequiresConstantAttributeTracer` and handle the `handleUndefinedConstants` parameter for custom outcome behavior.