### PR TITLE
[FEATURE] Introduce `#[ForbidsConstant]` attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,9 +64,206 @@ be added to the extension registration section like follows:
 
 The following attributes are shipped with this library:
 
+* [`#[ForbidsConstant]`](#forbidsconstant)
 * [`#[RequiresClass]`](#requiresclass)
 * [`#[RequiresConstant]`](#requiresconstant)
 * [`#[RequiresPackage]`](#requirespackage)
+
+### [`#[ForbidsConstant]`](src/Attribute/ForbidsConstant.php)
+
+_Scope: Class & Method level_
+
+With this attribute, tests or test cases can be marked as to be only executed
+if a certain constant does *not* exist. The constant can be defined globally or
+at class scope. The latter requires the appropriate class to be loadable by the
+current class loader (which normally is Composer's default class loader).
+
+#### Configuration
+
+By default, test cases requiring defined constants are skipped. However, this
+behavior can be configured by using the `handleDefinedConstants` extension
+parameter. If set to `fail`, test cases with defined constants will fail
+(defaults to `skip`):
+
+```xml
+<extensions>
+    <bootstrap class="EliasHaeussler\PHPUnitAttributes\PHPUnitAttributesExtension">
+        <parameter name="handleDefinedConstants" value="fail" />
+    </bootstrap>
+</extensions>
+```
+
+#### Example
+
+```php
+final class DummyTest extends TestCase
+{
+    #[ForbidsConstant('AN_ANNOYING_CONSTANT')]
+    public function testDummyAction(): void
+    {
+        // ...
+    }
+}
+```
+
+<details>
+<summary>More examples</summary>
+
+#### Forbid class constant
+
+Class level:
+
+```php
+#[ForbidsConstant(AnAnnoyingClass::class . '::AN_ANNOYING_CONSTANT')]
+final class DummyTest extends TestCase
+{
+    public function testDummyAction(): void
+    {
+        // Skipped if AnAnnoyingClass::AN_ANNOYING_CONSTANT is defined.
+    }
+
+    public function testOtherDummyAction(): void
+    {
+        // Skipped if AnAnnoyingClass::AN_ANNOYING_CONSTANT is defined.
+    }
+}
+```
+
+Method level:
+
+```php
+final class DummyTest extends TestCase
+{
+    #[ForbidsConstant(AnAnnoyingClass::class . '::AN_ANNOYING_CONSTANT')]
+    public function testDummyAction(): void
+    {
+        // Skipped if AnAnnoyingClass::AN_ANNOYING_CONSTANT is defined.
+    }
+
+    public function testOtherDummyAction(): void
+    {
+        // Not skipped.
+    }
+}
+```
+
+#### Forbid class constant and provide custom message
+
+Class level:
+
+```php
+#[ForbidsConstant(AnAnnoyingClass::class . '::AN_ANNOYING_CONSTANT', 'This test requires an important constant.')]
+final class DummyTest extends TestCase
+{
+    public function testDummyAction(): void
+    {
+        // Skipped if AnAnnoyingClass::AN_ANNOYING_CONSTANT is defined, along with custom message.
+    }
+
+    public function testOtherDummyAction(): void
+    {
+        // Skipped if AnAnnoyingClass::AN_ANNOYING_CONSTANT is defined, along with custom message.
+    }
+}
+```
+
+Method level:
+
+```php
+final class DummyTest extends TestCase
+{
+    #[ForbidsConstant(AnAnnoyingClass::class . '::AN_ANNOYING_CONSTANT', 'This test requires an important constant.')]
+    public function testDummyAction(): void
+    {
+        // Skipped if AnAnnoyingClass::AN_ANNOYING_CONSTANT is defined, along with custom message.
+    }
+
+    public function testOtherDummyAction(): void
+    {
+        // Not skipped.
+    }
+}
+```
+
+#### Forbid class constant and define custom outcome behavior
+
+Class level:
+
+```php
+#[ForbidsConstant(AnAnnoyingClass::class . '::AN_ANNOYING_CONSTANT', outcomeBehavior: OutcomeBehavior::Fail)]
+final class DummyTest extends TestCase
+{
+    public function testDummyAction(): void
+    {
+        // Fails if AnAnnoyingClass::AN_ANNOYING_CONSTANT is defined.
+    }
+
+    public function testOtherDummyAction(): void
+    {
+        // Fails if AnAnnoyingClass::AN_ANNOYING_CONSTANT is defined.
+    }
+}
+```
+
+Method level:
+
+```php
+final class DummyTest extends TestCase
+{
+    #[ForbidsConstant(AnAnnoyingClass::class . '::AN_ANNOYING_CONSTANT', outcomeBehavior: OutcomeBehavior::Fail)]
+    public function testDummyAction(): void
+    {
+        // Fails if AnAnnoyingClass::AN_ANNOYING_CONSTANT is defined.
+    }
+
+    public function testOtherDummyAction(): void
+    {
+        // Does not fail.
+    }
+}
+```
+
+#### Forbid multiple constants
+
+Class level:
+
+```php
+#[ForbidsConstant('SOME_IMPORTANT_CONSTANT')]
+#[ForbidsConstant('ANOTHER_VERY_IMPORTANT_CONSTANT')]
+final class DummyTest extends TestCase
+{
+    public function testDummyAction(): void
+    {
+        // Skipped if SOME_IMPORTANT_CONSTANT and/or ANOTHER_VERY_IMPORTANT_CONSTANT constants are defined.
+    }
+
+    public function testOtherDummyAction(): void
+    {
+        // Skipped if SOME_IMPORTANT_CONSTANT and/or ANOTHER_VERY_IMPORTANT_CONSTANT constants are defined.
+    }
+}
+```
+
+Method level:
+
+```php
+final class DummyTest extends TestCase
+{
+    #[ForbidsConstant('SOME_IMPORTANT_CONSTANT')]
+    #[ForbidsConstant('ANOTHER_VERY_IMPORTANT_CONSTANT')]
+    public function testDummyAction(): void
+    {
+        // Skipped if SOME_IMPORTANT_CONSTANT and/or ANOTHER_VERY_IMPORTANT_CONSTANT constants are defined.
+    }
+
+    public function testOtherDummyAction(): void
+    {
+        // Not skipped.
+    }
+}
+```
+
+</details>
 
 ### [`#[RequiresClass]`](src/Attribute/RequiresClass.php)
 

--- a/src/Attribute/ForbidsConstant.php
+++ b/src/Attribute/ForbidsConstant.php
@@ -21,38 +21,44 @@ declare(strict_types=1);
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
-namespace EliasHaeussler\PHPUnitAttributes\Metadata;
+namespace EliasHaeussler\PHPUnitAttributes\Attribute;
 
-use EliasHaeussler\PHPUnitAttributes\Attribute;
-use EliasHaeussler\PHPUnitAttributes\TextUI;
-
-use function defined;
+use Attribute;
+use EliasHaeussler\PHPUnitAttributes\Enum;
 
 /**
- * ConstantRequirements.
+ * ForbidsConstant.
  *
  * @author Elias Häußler <elias@haeussler.dev>
  * @license GPL-3.0-or-later
  */
-final class ConstantRequirements
+#[Attribute(Attribute::TARGET_METHOD | Attribute::TARGET_CLASS | Attribute::IS_REPEATABLE)]
+final class ForbidsConstant
 {
+    /**
+     * @param non-empty-string|null $message
+     */
+    public function __construct(
+        private readonly string $constant,
+        private readonly ?string $message = null,
+        private readonly ?Enum\OutcomeBehavior $outcomeBehavior = null,
+    ) {}
+
+    public function constant(): string
+    {
+        return $this->constant;
+    }
+
     /**
      * @return non-empty-string|null
      */
-    public function validateForAttribute(Attribute\RequiresConstant|Attribute\ForbidsConstant $attribute): ?string
+    public function message(): ?string
     {
-        $constant = $attribute->constant();
-        $message = $attribute->message();
-        $defined = @defined($constant);
+        return $this->message;
+    }
 
-        if (!$defined && $attribute instanceof Attribute\RequiresConstant) {
-            return $message ?? TextUI\Messages::forUndefinedConstant($constant);
-        }
-
-        if ($defined && $attribute instanceof Attribute\ForbidsConstant) {
-            return $message ?? TextUI\Messages::forDefinedConstant($constant);
-        }
-
-        return null;
+    public function outcomeBehavior(): ?Enum\OutcomeBehavior
+    {
+        return $this->outcomeBehavior;
     }
 }

--- a/src/Event/Tracer/ForbidsConstantAttributeTracer.php
+++ b/src/Event/Tracer/ForbidsConstantAttributeTracer.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/phpunit-attributes".
+ *
+ * Copyright (C) 2024-2025 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\PHPUnitAttributes\Event\Tracer;
+
+use EliasHaeussler\PHPUnitAttributes\Attribute;
+use EliasHaeussler\PHPUnitAttributes\Enum;
+use EliasHaeussler\PHPUnitAttributes\Metadata;
+
+/**
+ * ForbidsConstantAttributeTracer.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ *
+ * @extends AbstractAttributeTracer<Attribute\ForbidsConstant>
+ */
+final class ForbidsConstantAttributeTracer extends AbstractAttributeTracer
+{
+    public function __construct(
+        private readonly Metadata\ConstantRequirements $constantRequirements,
+        Enum\OutcomeBehavior $behaviorOnDefinedConstants,
+    ) {
+        $this->defaultOutcomeBehavior = $behaviorOnDefinedConstants;
+    }
+
+    protected function resolveBehaviorsFromAttributes(array $attributes): array
+    {
+        $notSatisfied = [];
+
+        foreach ($attributes as $attribute) {
+            $message = $this->constantRequirements->validateForAttribute($attribute);
+
+            if (null !== $message) {
+                $notSatisfied[$message] = $attribute->outcomeBehavior() ?? $this->defaultOutcomeBehavior;
+            }
+        }
+
+        return $notSatisfied;
+    }
+
+    protected function getAttributeClassName(): string
+    {
+        return Attribute\ForbidsConstant::class;
+    }
+}

--- a/src/PHPUnitAttributesExtension.php
+++ b/src/PHPUnitAttributesExtension.php
@@ -71,6 +71,19 @@ final class PHPUnitAttributesExtension implements Runner\Extension\Extension
             ),
         );
 
+        if ($parameters->has('handleDefinedConstants')) {
+            $handleDefinedConstants = Enum\OutcomeBehavior::tryFrom($parameters->get('handleDefinedConstants'));
+        } else {
+            $handleDefinedConstants = null;
+        }
+
+        $facade->registerTracer(
+            new Event\Tracer\ForbidsConstantAttributeTracer(
+                new Metadata\ConstantRequirements(),
+                $handleDefinedConstants ?? Enum\OutcomeBehavior::Skip,
+            ),
+        );
+
         $this->triggerDeprecationForMigratedConfigurationParameters(
             $configuration->colors(),
             $requiresPackageMigrationResult,

--- a/src/TextUI/Messages.php
+++ b/src/TextUI/Messages.php
@@ -70,4 +70,12 @@ final class Messages
     {
         return sprintf('Constant "%s" is required.', $constant);
     }
+
+    /**
+     * @return non-empty-string
+     */
+    public static function forDefinedConstant(string $constant): string
+    {
+        return sprintf('Constant "%s" is forbidden.', $constant);
+    }
 }

--- a/tests/e2e/forbids-constant-attribute/custom-message.phpt
+++ b/tests/e2e/forbids-constant-attribute/custom-message.phpt
@@ -1,0 +1,34 @@
+--TEST--
+The #[ForbidsConstant] attribute is applied with custom message
+--FILE--
+<?php
+
+declare(strict_types=1);
+
+$_SERVER['argv'][] = '--do-not-cache-result';
+$_SERVER['argv'][] = '--display-skipped';
+$_SERVER['argv'][] = '--configuration';
+$_SERVER['argv'][] = __DIR__ . '/fixtures/custom-message/phpunit.xml';
+
+require dirname(__DIR__, 3) . '/vendor/autoload.php';
+
+define('FOO_BAZ', 'bar');
+
+(new \PHPUnit\TextUI\Application())->run($_SERVER['argv']);
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+Runtime: %s
+Configuration: %s
+
+S                                                                   1 / 1 (100%)
+
+Time: %s, Memory: %s
+
+There was 1 skipped test:
+
+1) EliasHaeussler\PHPUnitAttributes\Tests\E2E\ForbidsConstantAttributeWithCustomMessageTest::fakeTest
+You've obviously defined some FOO...
+
+OK, but some tests were skipped!
+Tests: 1, Assertions: 0, Skipped: 1.

--- a/tests/e2e/forbids-constant-attribute/fail-on-unsatisfied-requirement.phpt
+++ b/tests/e2e/forbids-constant-attribute/fail-on-unsatisfied-requirement.phpt
@@ -1,0 +1,37 @@
+--TEST--
+The #[ForbidsConstant] attribute causes tests with unsatisified requirement to fail
+--FILE--
+<?php
+
+declare(strict_types=1);
+
+$_SERVER['argv'][] = '--do-not-cache-result';
+$_SERVER['argv'][] = '--configuration';
+$_SERVER['argv'][] = __DIR__ . '/fixtures/fail-on-unsatisfied-requirement/phpunit.xml';
+
+require dirname(__DIR__, 3) . '/vendor/autoload.php';
+
+define('FOO_BAZ', 'bar');
+
+(new \PHPUnit\TextUI\Application())->run($_SERVER['argv']);
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+Runtime: %s
+Configuration: %s
+
+F.                                                                  2 / 2 (100%)
+
+Time: %s, Memory: %s
+
+There was 1 failure:
+
+1) EliasHaeussler\PHPUnitAttributes\Tests\E2E\ForbidsConstantAttributeFailsOnUnsatisfiedRequirementTest::fakeTest
+Constant "FOO_BAZ" is forbidden.
+
+%s
+%s
+%s
+
+FAILURES!
+Tests: 2, Assertions: 2, Failures: 1.

--- a/tests/e2e/forbids-constant-attribute/fixtures/custom-message/phpunit.xml
+++ b/tests/e2e/forbids-constant-attribute/fixtures/custom-message/phpunit.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="../../../../../vendor/phpunit/phpunit/phpunit.xsd"
+>
+    <extensions>
+        <bootstrap class="EliasHaeussler\PHPUnitAttributes\PHPUnitAttributesExtension" />
+    </extensions>
+    <testsuites>
+        <testsuite name="default">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/tests/e2e/forbids-constant-attribute/fixtures/custom-message/tests/ForbidsConstantAttributeWithCustomMessageTest.php
+++ b/tests/e2e/forbids-constant-attribute/fixtures/custom-message/tests/ForbidsConstantAttributeWithCustomMessageTest.php
@@ -21,38 +21,23 @@ declare(strict_types=1);
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
-namespace EliasHaeussler\PHPUnitAttributes\Metadata;
+namespace EliasHaeussler\PHPUnitAttributes\Tests\E2E;
 
-use EliasHaeussler\PHPUnitAttributes\Attribute;
-use EliasHaeussler\PHPUnitAttributes\TextUI;
-
-use function defined;
+use EliasHaeussler\PHPUnitAttributes as Src;
+use PHPUnit\Framework;
 
 /**
- * ConstantRequirements.
+ * ForbidsConstantAttributeWithCustomMessageTest.
  *
  * @author Elias Häußler <elias@haeussler.dev>
  * @license GPL-3.0-or-later
  */
-final class ConstantRequirements
+final class ForbidsConstantAttributeWithCustomMessageTest extends Framework\TestCase
 {
-    /**
-     * @return non-empty-string|null
-     */
-    public function validateForAttribute(Attribute\RequiresConstant|Attribute\ForbidsConstant $attribute): ?string
+    #[Framework\Attributes\Test]
+    #[Src\Attribute\ForbidsConstant('FOO_BAZ', 'You\'ve obviously defined some FOO...')]
+    public function fakeTest(): void
     {
-        $constant = $attribute->constant();
-        $message = $attribute->message();
-        $defined = @defined($constant);
-
-        if (!$defined && $attribute instanceof Attribute\RequiresConstant) {
-            return $message ?? TextUI\Messages::forUndefinedConstant($constant);
-        }
-
-        if ($defined && $attribute instanceof Attribute\ForbidsConstant) {
-            return $message ?? TextUI\Messages::forDefinedConstant($constant);
-        }
-
-        return null;
+        self::assertTrue(true);
     }
 }

--- a/tests/e2e/forbids-constant-attribute/fixtures/fail-on-unsatisfied-requirement/phpunit.xml
+++ b/tests/e2e/forbids-constant-attribute/fixtures/fail-on-unsatisfied-requirement/phpunit.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="../../../../../vendor/phpunit/phpunit/phpunit.xsd"
+>
+    <extensions>
+        <bootstrap class="EliasHaeussler\PHPUnitAttributes\PHPUnitAttributesExtension">
+            <parameter name="handleDefinedConstants" value="fail" />
+        </bootstrap>
+    </extensions>
+    <testsuites>
+        <testsuite name="default">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/tests/e2e/forbids-constant-attribute/fixtures/fail-on-unsatisfied-requirement/tests/ForbidsConstantAttributeFailsOnUnsatisfiedRequirementTest.php
+++ b/tests/e2e/forbids-constant-attribute/fixtures/fail-on-unsatisfied-requirement/tests/ForbidsConstantAttributeFailsOnUnsatisfiedRequirementTest.php
@@ -21,38 +21,29 @@ declare(strict_types=1);
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
-namespace EliasHaeussler\PHPUnitAttributes\Metadata;
+namespace EliasHaeussler\PHPUnitAttributes\Tests\E2E;
 
-use EliasHaeussler\PHPUnitAttributes\Attribute;
-use EliasHaeussler\PHPUnitAttributes\TextUI;
-
-use function defined;
+use EliasHaeussler\PHPUnitAttributes as Src;
+use PHPUnit\Framework;
 
 /**
- * ConstantRequirements.
+ * ForbidsConstantAttributeFailsOnUnsatisfiedRequirementTest.
  *
  * @author Elias Häußler <elias@haeussler.dev>
  * @license GPL-3.0-or-later
  */
-final class ConstantRequirements
+final class ForbidsConstantAttributeFailsOnUnsatisfiedRequirementTest extends Framework\TestCase
 {
-    /**
-     * @return non-empty-string|null
-     */
-    public function validateForAttribute(Attribute\RequiresConstant|Attribute\ForbidsConstant $attribute): ?string
+    #[Framework\Attributes\Test]
+    #[Src\Attribute\ForbidsConstant('FOO_BAZ')]
+    public function fakeTest(): void
     {
-        $constant = $attribute->constant();
-        $message = $attribute->message();
-        $defined = @defined($constant);
+        self::assertTrue(true);
+    }
 
-        if (!$defined && $attribute instanceof Attribute\RequiresConstant) {
-            return $message ?? TextUI\Messages::forUndefinedConstant($constant);
-        }
-
-        if ($defined && $attribute instanceof Attribute\ForbidsConstant) {
-            return $message ?? TextUI\Messages::forDefinedConstant($constant);
-        }
-
-        return null;
+    #[Framework\Attributes\Test]
+    public function anotherFakeTest(): void
+    {
+        self::assertTrue(true);
     }
 }

--- a/tests/e2e/forbids-constant-attribute/fixtures/skip-on-invalid-configuration-value/phpunit.xml
+++ b/tests/e2e/forbids-constant-attribute/fixtures/skip-on-invalid-configuration-value/phpunit.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="../../../../../vendor/phpunit/phpunit/phpunit.xsd"
+>
+    <extensions>
+        <bootstrap class="EliasHaeussler\PHPUnitAttributes\PHPUnitAttributesExtension">
+            <!-- "foo" is invalid here by purpose, test verifies that it's normalized to ”skip" -->
+            <parameter name="handleDefinedConstants" value="foo" />
+        </bootstrap>
+    </extensions>
+    <testsuites>
+        <testsuite name="default">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/tests/e2e/forbids-constant-attribute/fixtures/skip-on-invalid-configuration-value/tests/ForbidsConstantAttributeSkipsOnInvalidConfigurationValueTest.php
+++ b/tests/e2e/forbids-constant-attribute/fixtures/skip-on-invalid-configuration-value/tests/ForbidsConstantAttributeSkipsOnInvalidConfigurationValueTest.php
@@ -21,38 +21,29 @@ declare(strict_types=1);
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
-namespace EliasHaeussler\PHPUnitAttributes\Metadata;
+namespace EliasHaeussler\PHPUnitAttributes\Tests\E2E;
 
-use EliasHaeussler\PHPUnitAttributes\Attribute;
-use EliasHaeussler\PHPUnitAttributes\TextUI;
-
-use function defined;
+use EliasHaeussler\PHPUnitAttributes as Src;
+use PHPUnit\Framework;
 
 /**
- * ConstantRequirements.
+ * ForbidsConstantAttributeSkipsOnInvalidConfigurationValueTest.
  *
  * @author Elias Häußler <elias@haeussler.dev>
  * @license GPL-3.0-or-later
  */
-final class ConstantRequirements
+final class ForbidsConstantAttributeSkipsOnInvalidConfigurationValueTest extends Framework\TestCase
 {
-    /**
-     * @return non-empty-string|null
-     */
-    public function validateForAttribute(Attribute\RequiresConstant|Attribute\ForbidsConstant $attribute): ?string
+    #[Framework\Attributes\Test]
+    #[Src\Attribute\ForbidsConstant('FOO_BAZ')]
+    public function fakeTest(): void
     {
-        $constant = $attribute->constant();
-        $message = $attribute->message();
-        $defined = @defined($constant);
+        self::assertTrue(true);
+    }
 
-        if (!$defined && $attribute instanceof Attribute\RequiresConstant) {
-            return $message ?? TextUI\Messages::forUndefinedConstant($constant);
-        }
-
-        if ($defined && $attribute instanceof Attribute\ForbidsConstant) {
-            return $message ?? TextUI\Messages::forDefinedConstant($constant);
-        }
-
-        return null;
+    #[Framework\Attributes\Test]
+    public function anotherFakeTest(): void
+    {
+        self::assertTrue(true);
     }
 }

--- a/tests/e2e/forbids-constant-attribute/fixtures/skip-on-unsatisfied-requirement/phpunit.xml
+++ b/tests/e2e/forbids-constant-attribute/fixtures/skip-on-unsatisfied-requirement/phpunit.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="../../../../../vendor/phpunit/phpunit/phpunit.xsd"
+>
+    <extensions>
+        <bootstrap class="EliasHaeussler\PHPUnitAttributes\PHPUnitAttributesExtension">
+            <parameter name="handleDefinedConstants" value="skip" />
+        </bootstrap>
+    </extensions>
+    <testsuites>
+        <testsuite name="default">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/tests/e2e/forbids-constant-attribute/fixtures/skip-on-unsatisfied-requirement/tests/ForbidsConstantAttributeSkipsOnUnsatisfiedRequirementTest.php
+++ b/tests/e2e/forbids-constant-attribute/fixtures/skip-on-unsatisfied-requirement/tests/ForbidsConstantAttributeSkipsOnUnsatisfiedRequirementTest.php
@@ -21,38 +21,29 @@ declare(strict_types=1);
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
-namespace EliasHaeussler\PHPUnitAttributes\Metadata;
+namespace EliasHaeussler\PHPUnitAttributes\Tests\E2E;
 
-use EliasHaeussler\PHPUnitAttributes\Attribute;
-use EliasHaeussler\PHPUnitAttributes\TextUI;
-
-use function defined;
+use EliasHaeussler\PHPUnitAttributes as Src;
+use PHPUnit\Framework;
 
 /**
- * ConstantRequirements.
+ * ForbidsConstantAttributeSkipsOnUnsatisfiedRequirementTest.
  *
  * @author Elias Häußler <elias@haeussler.dev>
  * @license GPL-3.0-or-later
  */
-final class ConstantRequirements
+final class ForbidsConstantAttributeSkipsOnUnsatisfiedRequirementTest extends Framework\TestCase
 {
-    /**
-     * @return non-empty-string|null
-     */
-    public function validateForAttribute(Attribute\RequiresConstant|Attribute\ForbidsConstant $attribute): ?string
+    #[Framework\Attributes\Test]
+    #[Src\Attribute\ForbidsConstant('FOO_BAZ')]
+    public function fakeTest(): void
     {
-        $constant = $attribute->constant();
-        $message = $attribute->message();
-        $defined = @defined($constant);
+        self::assertTrue(true);
+    }
 
-        if (!$defined && $attribute instanceof Attribute\RequiresConstant) {
-            return $message ?? TextUI\Messages::forUndefinedConstant($constant);
-        }
-
-        if ($defined && $attribute instanceof Attribute\ForbidsConstant) {
-            return $message ?? TextUI\Messages::forDefinedConstant($constant);
-        }
-
-        return null;
+    #[Framework\Attributes\Test]
+    public function anotherFakeTest(): void
+    {
+        self::assertTrue(true);
     }
 }

--- a/tests/e2e/forbids-constant-attribute/skip-on-invalid-configuration-value.phpt
+++ b/tests/e2e/forbids-constant-attribute/skip-on-invalid-configuration-value.phpt
@@ -1,0 +1,34 @@
+--TEST--
+Invalid configuration options are normalized to tests with unsatisfied requirements being skipped
+--FILE--
+<?php
+
+declare(strict_types=1);
+
+$_SERVER['argv'][] = '--do-not-cache-result';
+$_SERVER['argv'][] = '--display-skipped';
+$_SERVER['argv'][] = '--configuration';
+$_SERVER['argv'][] = __DIR__ . '/fixtures/skip-on-invalid-configuration-value/phpunit.xml';
+
+require dirname(__DIR__, 3) . '/vendor/autoload.php';
+
+define('FOO_BAZ', 'bar');
+
+(new \PHPUnit\TextUI\Application())->run($_SERVER['argv']);
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+Runtime: %s
+Configuration: %s
+
+S.                                                                  2 / 2 (100%)
+
+Time: %s, Memory: %s
+
+There was 1 skipped test:
+
+1) EliasHaeussler\PHPUnitAttributes\Tests\E2E\ForbidsConstantAttributeSkipsOnInvalidConfigurationValueTest::fakeTest
+Constant "FOO_BAZ" is forbidden.
+
+OK, but some tests were skipped!
+Tests: 2, Assertions: 1, Skipped: 1.

--- a/tests/e2e/forbids-constant-attribute/skip-on-unsatisfied-requirement.phpt
+++ b/tests/e2e/forbids-constant-attribute/skip-on-unsatisfied-requirement.phpt
@@ -1,0 +1,34 @@
+--TEST--
+The #[ForbidsConstant] attribute causes tests with unsatisified requirement to be skipped
+--FILE--
+<?php
+
+declare(strict_types=1);
+
+$_SERVER['argv'][] = '--do-not-cache-result';
+$_SERVER['argv'][] = '--display-skipped';
+$_SERVER['argv'][] = '--configuration';
+$_SERVER['argv'][] = __DIR__ . '/fixtures/skip-on-unsatisfied-requirement/phpunit.xml';
+
+require dirname(__DIR__, 3) . '/vendor/autoload.php';
+
+define('FOO_BAZ', 'bar');
+
+(new \PHPUnit\TextUI\Application())->run($_SERVER['argv']);
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+Runtime: %s
+Configuration: %s
+
+S.                                                                  2 / 2 (100%)
+
+Time: %s, Memory: %s
+
+There was 1 skipped test:
+
+1) EliasHaeussler\PHPUnitAttributes\Tests\E2E\ForbidsConstantAttributeSkipsOnUnsatisfiedRequirementTest::fakeTest
+Constant "FOO_BAZ" is forbidden.
+
+OK, but some tests were skipped!
+Tests: 2, Assertions: 1, Skipped: 1.

--- a/tests/unit/TextUI/MessagesTest.php
+++ b/tests/unit/TextUI/MessagesTest.php
@@ -64,4 +64,22 @@ final class MessagesTest extends Framework\TestCase
             Src\TextUI\Messages::forMissingClass(self::class),
         );
     }
+
+    #[Framework\Attributes\Test]
+    public function forUndefinedConstantReturnsMessageForGivenConstant(): void
+    {
+        self::assertSame(
+            'Constant "FOO_BAZ" is required.',
+            Src\TextUI\Messages::forUndefinedConstant('FOO_BAZ'),
+        );
+    }
+
+    #[Framework\Attributes\Test]
+    public function forDefinedConstantReturnsMessageForGivenConstant(): void
+    {
+        self::assertSame(
+            'Constant "FOO_BAZ" is forbidden.',
+            Src\TextUI\Messages::forDefinedConstant('FOO_BAZ'),
+        );
+    }
 }


### PR DESCRIPTION
This pull request introduces a new attribute, `#[ForbidsConstant]`, to the PHPUnit Attributes library. This attribute allows tests to be skipped or failed if a specified constant is defined, enhancing the flexibility of test case requirements. Below are the most important changes included in this pull request:

### Documentation Updates:
* Added documentation for the new `#[ForbidsConstant]` attribute in the `README.md` file, including its scope, configuration, and usage examples.

### New Attribute Implementation:
* Introduced the `ForbidsConstant` attribute class in `src/Attribute/ForbidsConstant.php`, which includes properties for the constant name, an optional message, and an optional outcome behavior.

### Event Tracing:
* Added a new tracer class, `ForbidsConstantAttributeTracer`, in `src/Event/Tracer/ForbidsConstantAttributeTracer.php`, responsible for handling the behavior of the `ForbidsConstant` attribute during test execution.

### Metadata Handling:
* Updated the `ConstantRequirements` class in `src/Metadata/ConstantRequirements.php` to validate the `ForbidsConstant` attribute, ensuring tests are skipped or failed based on the defined constants.

### Configuration and Test Cases:
* Modified the `PHPUnitAttributesExtension` class to register the new tracer and handle the configuration parameter `handleDefinedConstants`.
* Added end-to-end test cases to validate the behavior of the `ForbidsConstant` attribute under various scenarios, including custom messages and different outcome behaviors. [[1]](diffhunk://#diff-962cd88179f2c2ed99a7aa1c8bb1d1a9e0e25028421015cd5018487537e4c80dR1-R34) [[2]](diffhunk://#diff-285ef2f41998fea92c7ca3018983dca9120c79c3279ccc33680ae8476091759aR1-R37) [[3]](diffhunk://#diff-107133de5beaffbc616ea12f616bd1e4f74e68baa49b7dcfd2ea515632cbaa41R1-R13) [[4]](diffhunk://#diff-f4ef252ed3a5b9b0163738b09b0df412cac6bec75286627df67972f48c51d65cR1-R43) [[5]](diffhunk://#diff-b49b3803d7edaaf88a44e2cb87957f8fb06e547bfe89b5f8b46e0087a3d66938R1-R15) [[6]](diffhunk://#diff-d057f7e4eaaef9a7f7f30f9755af6998fb12a72a4daa3d6fc06fd3c537a479fbR1-R49) [[7]](diffhunk://#diff-e68e1ca75b3cfab8bf7862b6adfcfd01fbc16184725502bb25495dd7be5ae773R1-R16) [[8]](diffhunk://#diff-c27b40ab40c31adceb6026e6ff3bb05458f4e370a7add736989c68cac60a6196R1-R49) [[9]](diffhunk://#diff-f44fc9749bb5c6f9b053569e9618741bc9ab24d912a93361822d7c8acab6dd71R1-R15)