### PR TITLE
[FEATURE] Introduce `#[ForbidsClass]` attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ be added to the extension registration section like follows:
 
 The following attributes are shipped with this library:
 
+* [`#[ForbidsClass]`](docs/attributes/forbids-class.md)
 * [`#[ForbidsConstant]`](docs/attributes/forbids-constant.md)
 * [`#[RequiresClass]`](docs/attributes/requires-class.md)
 * [`#[RequiresConstant]`](docs/attributes/requires-constant.md)

--- a/docs/attributes/forbids-class.md
+++ b/docs/attributes/forbids-class.md
@@ -1,0 +1,192 @@
+# [`#[ForbidsClass]`](../../src/Attribute/ForbidsClass.php)
+
+_Scope: Class & Method level_
+
+With this attribute, tests or test cases can be marked as to be only executed
+if a certain class does *not* exist.
+
+## Configuration
+
+By default, test cases requiring existent classes are skipped. However, this
+behavior can be configured by using the `handleAvailableClasses` extension parameter.
+If set to `fail`, test cases with available classes will fail (defaults to `skip`):
+
+```xml
+<extensions>
+    <bootstrap class="EliasHaeussler\PHPUnitAttributes\PHPUnitAttributesExtension">
+        <parameter name="handleAvailableClasses" value="fail" />
+    </bootstrap>
+</extensions>
+```
+
+## Example
+
+```php
+final class DummyTest extends TestCase
+{
+    #[ForbidsClass('AnAbsentClass')]
+    public function testDummyAction(): void
+    {
+        // ...
+    }
+}
+```
+
+<details>
+<summary>More examples</summary>
+
+### Forbid single class
+
+Class level:
+
+```php
+#[ForbidsClass('AnAbsentClass')]
+final class DummyTest extends TestCase
+{
+    public function testDummyAction(): void
+    {
+        // Skipped if AnAbsentClass is available.
+    }
+
+    public function testOtherDummyAction(): void
+    {
+        // Skipped if AnAbsentClass is available.
+    }
+}
+```
+
+Method level:
+
+```php
+final class DummyTest extends TestCase
+{
+    #[ForbidsClass('AnAbsentClass')]
+    public function testDummyAction(): void
+    {
+        // Skipped if AnAbsentClass is available.
+    }
+
+    public function testOtherDummyAction(): void
+    {
+        // Not skipped.
+    }
+}
+```
+
+### Forbid single class and provide custom message
+
+Class level:
+
+```php
+#[ForbidsClass('AnAbsentClass', 'This test forbids the `AnAbsentClass` class.')]
+final class DummyTest extends TestCase
+{
+    public function testDummyAction(): void
+    {
+        // Skipped if AnAbsentClass is available, along with custom message.
+    }
+
+    public function testOtherDummyAction(): void
+    {
+        // Skipped if AnAbsentClass is available, along with custom message.
+    }
+}
+```
+
+Method level:
+
+```php
+final class DummyTest extends TestCase
+{
+    #[ForbidsClass('AnAbsentClass', 'This test requires the `AnAbsentClass` class.')]
+    public function testDummyAction(): void
+    {
+        // Skipped if AnAbsentClass is available, along with custom message.
+    }
+
+    public function testOtherDummyAction(): void
+    {
+        // Not skipped.
+    }
+}
+```
+
+### Forbid single class and define custom outcome behavior
+
+Class level:
+
+```php
+#[ForbidsClass('AnAbsentClass', outcomeBehavior: OutcomeBehavior::Fail)]
+final class DummyTest extends TestCase
+{
+    public function testDummyAction(): void
+    {
+        // Fails if AnAbsentClass is available.
+    }
+
+    public function testOtherDummyAction(): void
+    {
+        // Fails if AnAbsentClass is available.
+    }
+}
+```
+
+Method level:
+
+```php
+final class DummyTest extends TestCase
+{
+    #[ForbidsClass('AnAbsentClass', outcomeBehavior: OutcomeBehavior::Fail)]
+    public function testDummyAction(): void
+    {
+        // Fails if AnAbsentClass is available.
+    }
+
+    public function testOtherDummyAction(): void
+    {
+        // Does not fail.
+    }
+}
+```
+
+### Forbid multiple classes
+
+Class level:
+
+```php
+#[ForbidsClass('AnAbsentClass')]
+#[ForbidsClass('AnotherUnimportantClass')]
+final class DummyTest extends TestCase
+{
+    public function testDummyAction(): void
+    {
+        // Skipped if AnAbsentClass and/or AnotherUnimportantClass are available.
+    }
+
+    public function testOtherDummyAction(): void
+    {
+        // Skipped if AnAbsentClass and/or AnotherUnimportantClass are available.
+    }
+}
+```
+
+Method level:
+
+```php
+final class DummyTest extends TestCase
+{
+    #[ForbidsClass('AnAbsentClass')]
+    #[ForbidsClass('AnotherUnimportantClass')]
+    public function testDummyAction(): void
+    {
+        // Skipped if AnAbsentClass and/or AnotherUnimportantClass are available.
+    }
+
+    public function testOtherDummyAction(): void
+    {
+        // Not skipped.
+    }
+}
+```
+
+</details>

--- a/docs/attributes/forbids-constant.md
+++ b/docs/attributes/forbids-constant.md
@@ -81,7 +81,7 @@ final class DummyTest extends TestCase
 Class level:
 
 ```php
-#[ForbidsConstant(AnAnnoyingClass::class . '::AN_ANNOYING_CONSTANT', 'This test requires an important constant.')]
+#[ForbidsConstant(AnAnnoyingClass::class . '::AN_ANNOYING_CONSTANT', 'This test forbids an important constant.')]
 final class DummyTest extends TestCase
 {
     public function testDummyAction(): void

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -49,6 +49,12 @@ parameters:
 			path: tests/e2e/requires-class-attribute/fixtures/skip-on-unsatisfied-requirement/tests/RequiresClassAttributeSkipsOnUnsatisfiedRequirementTest.php
 
 		-
+			message: '#^Parameter \#1 \$className of class EliasHaeussler\\PHPUnitAttributes\\Attribute\\ForbidsClass constructor expects class\-string, string given\.$#'
+			identifier: argument.type
+			count: 1
+			path: tests/unit/Metadata/ClassRequirementsTest.php
+
+		-
 			message: '#^Parameter \#1 \$className of class EliasHaeussler\\PHPUnitAttributes\\Attribute\\RequiresClass constructor expects class\-string, string given\.$#'
 			identifier: argument.type
 			count: 1

--- a/src/Attribute/ForbidsClass.php
+++ b/src/Attribute/ForbidsClass.php
@@ -21,38 +21,48 @@ declare(strict_types=1);
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
-namespace EliasHaeussler\PHPUnitAttributes\Metadata;
+namespace EliasHaeussler\PHPUnitAttributes\Attribute;
 
-use EliasHaeussler\PHPUnitAttributes\Attribute;
-use EliasHaeussler\PHPUnitAttributes\TextUI;
-
-use function class_exists;
+use Attribute;
+use EliasHaeussler\PHPUnitAttributes\Enum;
 
 /**
- * ClassRequirements.
+ * FOrbidsClass.
  *
  * @author Elias Häußler <elias@haeussler.dev>
  * @license GPL-3.0-or-later
  */
-final class ClassRequirements
+#[Attribute(Attribute::TARGET_METHOD | Attribute::TARGET_CLASS | Attribute::IS_REPEATABLE)]
+final class ForbidsClass
 {
+    /**
+     * @param class-string          $className
+     * @param non-empty-string|null $message
+     */
+    public function __construct(
+        private readonly string $className,
+        private readonly ?string $message = null,
+        private readonly ?Enum\OutcomeBehavior $outcomeBehavior = null,
+    ) {}
+
+    /**
+     * @return class-string
+     */
+    public function className(): string
+    {
+        return $this->className;
+    }
+
     /**
      * @return non-empty-string|null
      */
-    public function validateForAttribute(Attribute\RequiresClass|Attribute\ForbidsClass $attribute): ?string
+    public function message(): ?string
     {
-        $className = $attribute->className();
-        $message = $attribute->message();
-        $classExists = @class_exists($className);
+        return $this->message;
+    }
 
-        if (!$classExists && $attribute instanceof Attribute\RequiresClass) {
-            return $message ?? TextUI\Messages::forMissingClass($className);
-        }
-
-        if ($classExists && $attribute instanceof Attribute\ForbidsClass) {
-            return $message ?? TextUI\Messages::forAvailableClass($className);
-        }
-
-        return null;
+    public function outcomeBehavior(): ?Enum\OutcomeBehavior
+    {
+        return $this->outcomeBehavior;
     }
 }

--- a/src/Event/Tracer/ForbidsClassAttributeTracer.php
+++ b/src/Event/Tracer/ForbidsClassAttributeTracer.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/phpunit-attributes".
+ *
+ * Copyright (C) 2024-2025 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\PHPUnitAttributes\Event\Tracer;
+
+use EliasHaeussler\PHPUnitAttributes\Attribute;
+use EliasHaeussler\PHPUnitAttributes\Enum;
+use EliasHaeussler\PHPUnitAttributes\Metadata;
+
+/**
+ * ForbidsClassAttributeTracer.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ *
+ * @extends AbstractAttributeTracer<Attribute\ForbidsClass>
+ */
+final class ForbidsClassAttributeTracer extends AbstractAttributeTracer
+{
+    public function __construct(
+        private readonly Metadata\ClassRequirements $classRequirements,
+        Enum\OutcomeBehavior $behaviorOnAvailableClasses,
+    ) {
+        $this->defaultOutcomeBehavior = $behaviorOnAvailableClasses;
+    }
+
+    protected function resolveBehaviorsFromAttributes(array $attributes): array
+    {
+        $notSatisfied = [];
+
+        foreach ($attributes as $attribute) {
+            $message = $this->classRequirements->validateForAttribute($attribute);
+
+            if (null !== $message) {
+                $notSatisfied[$message] = $attribute->outcomeBehavior() ?? $this->defaultOutcomeBehavior;
+            }
+        }
+
+        return $notSatisfied;
+    }
+
+    protected function getAttributeClassName(): string
+    {
+        return Attribute\ForbidsClass::class;
+    }
+}

--- a/src/TextUI/Messages.php
+++ b/src/TextUI/Messages.php
@@ -64,6 +64,16 @@ final class Messages
     }
 
     /**
+     * @param class-string $className
+     *
+     * @return non-empty-string
+     */
+    public static function forAvailableClass(string $className): string
+    {
+        return sprintf('Class "%s" is forbidden.', $className);
+    }
+
+    /**
      * @return non-empty-string
      */
     public static function forUndefinedConstant(string $constant): string

--- a/tests/e2e/forbids-class-attribute/custom-message.phpt
+++ b/tests/e2e/forbids-class-attribute/custom-message.phpt
@@ -1,0 +1,32 @@
+--TEST--
+The #[ForbidsClass] attribute is applied with custom message
+--FILE--
+<?php
+
+declare(strict_types=1);
+
+$_SERVER['argv'][] = '--do-not-cache-result';
+$_SERVER['argv'][] = '--display-skipped';
+$_SERVER['argv'][] = '--configuration';
+$_SERVER['argv'][] = __DIR__ . '/fixtures/custom-message/phpunit.xml';
+
+require dirname(__DIR__, 3) . '/vendor/autoload.php';
+
+(new \PHPUnit\TextUI\Application())->run($_SERVER['argv']);
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+Runtime: %s
+Configuration: %s
+
+S                                                                   1 / 1 (100%)
+
+Time: %s, Memory: %s
+
+There was 1 skipped test:
+
+1) EliasHaeussler\PHPUnitAttributes\Tests\E2E\ForbidsClassAttributeWithCustomMessageTest::fakeTest
+You're obviously having some Exception...
+
+OK, but some tests were skipped!
+Tests: 1, Assertions: 0, Skipped: 1.

--- a/tests/e2e/forbids-class-attribute/fail-on-unsatisfied-requirement.phpt
+++ b/tests/e2e/forbids-class-attribute/fail-on-unsatisfied-requirement.phpt
@@ -1,0 +1,35 @@
+--TEST--
+The #[ForbidsClass] attribute causes tests with unsatisified requirement to fail
+--FILE--
+<?php
+
+declare(strict_types=1);
+
+$_SERVER['argv'][] = '--do-not-cache-result';
+$_SERVER['argv'][] = '--configuration';
+$_SERVER['argv'][] = __DIR__ . '/fixtures/fail-on-unsatisfied-requirement/phpunit.xml';
+
+require dirname(__DIR__, 3) . '/vendor/autoload.php';
+
+(new \PHPUnit\TextUI\Application())->run($_SERVER['argv']);
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+Runtime: %s
+Configuration: %s
+
+F.                                                                  2 / 2 (100%)
+
+Time: %s, Memory: %s
+
+There was 1 failure:
+
+1) EliasHaeussler\PHPUnitAttributes\Tests\E2E\ForbidsClassAttributeFailsOnUnsatisfiedRequirementTest::fakeTest
+Class "Exception" is forbidden.
+
+%s
+%s
+%s
+
+FAILURES!
+Tests: 2, Assertions: 2, Failures: 1.

--- a/tests/e2e/forbids-class-attribute/fixtures/custom-message/phpunit.xml
+++ b/tests/e2e/forbids-class-attribute/fixtures/custom-message/phpunit.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="../../../../../vendor/phpunit/phpunit/phpunit.xsd"
+>
+    <extensions>
+        <bootstrap class="EliasHaeussler\PHPUnitAttributes\PHPUnitAttributesExtension" />
+    </extensions>
+    <testsuites>
+        <testsuite name="default">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/tests/e2e/forbids-class-attribute/fixtures/custom-message/tests/ForbidsClassAttributeWithCustomMessageTest.php
+++ b/tests/e2e/forbids-class-attribute/fixtures/custom-message/tests/ForbidsClassAttributeWithCustomMessageTest.php
@@ -21,38 +21,24 @@ declare(strict_types=1);
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
-namespace EliasHaeussler\PHPUnitAttributes\Metadata;
+namespace EliasHaeussler\PHPUnitAttributes\Tests\E2E;
 
-use EliasHaeussler\PHPUnitAttributes\Attribute;
-use EliasHaeussler\PHPUnitAttributes\TextUI;
-
-use function class_exists;
+use EliasHaeussler\PHPUnitAttributes as Src;
+use Exception;
+use PHPUnit\Framework;
 
 /**
- * ClassRequirements.
+ * ForbidsClassAttributeWithCustomMessageTest.
  *
  * @author Elias Häußler <elias@haeussler.dev>
  * @license GPL-3.0-or-later
  */
-final class ClassRequirements
+final class ForbidsClassAttributeWithCustomMessageTest extends Framework\TestCase
 {
-    /**
-     * @return non-empty-string|null
-     */
-    public function validateForAttribute(Attribute\RequiresClass|Attribute\ForbidsClass $attribute): ?string
+    #[Framework\Attributes\Test]
+    #[Src\Attribute\ForbidsClass(Exception::class, 'You\'re obviously having some Exception...')]
+    public function fakeTest(): void
     {
-        $className = $attribute->className();
-        $message = $attribute->message();
-        $classExists = @class_exists($className);
-
-        if (!$classExists && $attribute instanceof Attribute\RequiresClass) {
-            return $message ?? TextUI\Messages::forMissingClass($className);
-        }
-
-        if ($classExists && $attribute instanceof Attribute\ForbidsClass) {
-            return $message ?? TextUI\Messages::forAvailableClass($className);
-        }
-
-        return null;
+        self::assertTrue(true);
     }
 }

--- a/tests/e2e/forbids-class-attribute/fixtures/fail-on-unsatisfied-requirement/phpunit.xml
+++ b/tests/e2e/forbids-class-attribute/fixtures/fail-on-unsatisfied-requirement/phpunit.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="../../../../../vendor/phpunit/phpunit/phpunit.xsd"
+>
+    <extensions>
+        <bootstrap class="EliasHaeussler\PHPUnitAttributes\PHPUnitAttributesExtension">
+            <parameter name="handleAvailableClasses" value="fail" />
+        </bootstrap>
+    </extensions>
+    <testsuites>
+        <testsuite name="default">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/tests/e2e/forbids-class-attribute/fixtures/fail-on-unsatisfied-requirement/tests/ForbidsClassAttributeFailsOnUnsatisfiedRequirementTest.php
+++ b/tests/e2e/forbids-class-attribute/fixtures/fail-on-unsatisfied-requirement/tests/ForbidsClassAttributeFailsOnUnsatisfiedRequirementTest.php
@@ -21,38 +21,30 @@ declare(strict_types=1);
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
-namespace EliasHaeussler\PHPUnitAttributes\Metadata;
+namespace EliasHaeussler\PHPUnitAttributes\Tests\E2E;
 
-use EliasHaeussler\PHPUnitAttributes\Attribute;
-use EliasHaeussler\PHPUnitAttributes\TextUI;
-
-use function class_exists;
+use EliasHaeussler\PHPUnitAttributes as Src;
+use Exception;
+use PHPUnit\Framework;
 
 /**
- * ClassRequirements.
+ * ForbidsClassAttributeFailsOnUnsatisfiedRequirementTest.
  *
  * @author Elias Häußler <elias@haeussler.dev>
  * @license GPL-3.0-or-later
  */
-final class ClassRequirements
+final class ForbidsClassAttributeFailsOnUnsatisfiedRequirementTest extends Framework\TestCase
 {
-    /**
-     * @return non-empty-string|null
-     */
-    public function validateForAttribute(Attribute\RequiresClass|Attribute\ForbidsClass $attribute): ?string
+    #[Framework\Attributes\Test]
+    #[Src\Attribute\ForbidsClass(Exception::class)]
+    public function fakeTest(): void
     {
-        $className = $attribute->className();
-        $message = $attribute->message();
-        $classExists = @class_exists($className);
+        self::assertTrue(true);
+    }
 
-        if (!$classExists && $attribute instanceof Attribute\RequiresClass) {
-            return $message ?? TextUI\Messages::forMissingClass($className);
-        }
-
-        if ($classExists && $attribute instanceof Attribute\ForbidsClass) {
-            return $message ?? TextUI\Messages::forAvailableClass($className);
-        }
-
-        return null;
+    #[Framework\Attributes\Test]
+    public function anotherFakeTest(): void
+    {
+        self::assertTrue(true);
     }
 }

--- a/tests/e2e/forbids-class-attribute/fixtures/skip-on-invalid-configuration-value/phpunit.xml
+++ b/tests/e2e/forbids-class-attribute/fixtures/skip-on-invalid-configuration-value/phpunit.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="../../../../../vendor/phpunit/phpunit/phpunit.xsd"
+>
+    <extensions>
+        <bootstrap class="EliasHaeussler\PHPUnitAttributes\PHPUnitAttributesExtension">
+            <!-- "foo" is invalid here by purpose, test verifies that it's normalized to ”skip" -->
+            <parameter name="handleAvailableClasses" value="foo" />
+        </bootstrap>
+    </extensions>
+    <testsuites>
+        <testsuite name="default">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/tests/e2e/forbids-class-attribute/fixtures/skip-on-invalid-configuration-value/tests/ForbidsClassAttributeSkipsOnInvalidConfigurationValueTest.php
+++ b/tests/e2e/forbids-class-attribute/fixtures/skip-on-invalid-configuration-value/tests/ForbidsClassAttributeSkipsOnInvalidConfigurationValueTest.php
@@ -21,38 +21,30 @@ declare(strict_types=1);
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
-namespace EliasHaeussler\PHPUnitAttributes\Metadata;
+namespace EliasHaeussler\PHPUnitAttributes\Tests\E2E;
 
-use EliasHaeussler\PHPUnitAttributes\Attribute;
-use EliasHaeussler\PHPUnitAttributes\TextUI;
-
-use function class_exists;
+use EliasHaeussler\PHPUnitAttributes as Src;
+use Exception;
+use PHPUnit\Framework;
 
 /**
- * ClassRequirements.
+ * ForbidsClassAttributeSkipsOnInvalidConfigurationValueTest.
  *
  * @author Elias Häußler <elias@haeussler.dev>
  * @license GPL-3.0-or-later
  */
-final class ClassRequirements
+final class ForbidsClassAttributeSkipsOnInvalidConfigurationValueTest extends Framework\TestCase
 {
-    /**
-     * @return non-empty-string|null
-     */
-    public function validateForAttribute(Attribute\RequiresClass|Attribute\ForbidsClass $attribute): ?string
+    #[Framework\Attributes\Test]
+    #[Src\Attribute\ForbidsClass(Exception::class)]
+    public function fakeTest(): void
     {
-        $className = $attribute->className();
-        $message = $attribute->message();
-        $classExists = @class_exists($className);
+        self::assertTrue(true);
+    }
 
-        if (!$classExists && $attribute instanceof Attribute\RequiresClass) {
-            return $message ?? TextUI\Messages::forMissingClass($className);
-        }
-
-        if ($classExists && $attribute instanceof Attribute\ForbidsClass) {
-            return $message ?? TextUI\Messages::forAvailableClass($className);
-        }
-
-        return null;
+    #[Framework\Attributes\Test]
+    public function anotherFakeTest(): void
+    {
+        self::assertTrue(true);
     }
 }

--- a/tests/e2e/forbids-class-attribute/fixtures/skip-on-unsatisfied-requirement/phpunit.xml
+++ b/tests/e2e/forbids-class-attribute/fixtures/skip-on-unsatisfied-requirement/phpunit.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="../../../../../vendor/phpunit/phpunit/phpunit.xsd"
+>
+    <extensions>
+        <bootstrap class="EliasHaeussler\PHPUnitAttributes\PHPUnitAttributesExtension">
+            <parameter name="handleAvailableClasses" value="skip" />
+        </bootstrap>
+    </extensions>
+    <testsuites>
+        <testsuite name="default">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/tests/e2e/forbids-class-attribute/fixtures/skip-on-unsatisfied-requirement/tests/ForbidsClassAttributeSkipsOnUnsatisfiedRequirementTest.php
+++ b/tests/e2e/forbids-class-attribute/fixtures/skip-on-unsatisfied-requirement/tests/ForbidsClassAttributeSkipsOnUnsatisfiedRequirementTest.php
@@ -21,38 +21,30 @@ declare(strict_types=1);
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
-namespace EliasHaeussler\PHPUnitAttributes\Metadata;
+namespace EliasHaeussler\PHPUnitAttributes\Tests\E2E;
 
-use EliasHaeussler\PHPUnitAttributes\Attribute;
-use EliasHaeussler\PHPUnitAttributes\TextUI;
-
-use function class_exists;
+use EliasHaeussler\PHPUnitAttributes as Src;
+use Exception;
+use PHPUnit\Framework;
 
 /**
- * ClassRequirements.
+ * ForbidsClassAttributeSkipsOnUnsatisfiedRequirementTest.
  *
  * @author Elias Häußler <elias@haeussler.dev>
  * @license GPL-3.0-or-later
  */
-final class ClassRequirements
+final class ForbidsClassAttributeSkipsOnUnsatisfiedRequirementTest extends Framework\TestCase
 {
-    /**
-     * @return non-empty-string|null
-     */
-    public function validateForAttribute(Attribute\RequiresClass|Attribute\ForbidsClass $attribute): ?string
+    #[Framework\Attributes\Test]
+    #[Src\Attribute\ForbidsClass(Exception::class)]
+    public function fakeTest(): void
     {
-        $className = $attribute->className();
-        $message = $attribute->message();
-        $classExists = @class_exists($className);
+        self::assertTrue(true);
+    }
 
-        if (!$classExists && $attribute instanceof Attribute\RequiresClass) {
-            return $message ?? TextUI\Messages::forMissingClass($className);
-        }
-
-        if ($classExists && $attribute instanceof Attribute\ForbidsClass) {
-            return $message ?? TextUI\Messages::forAvailableClass($className);
-        }
-
-        return null;
+    #[Framework\Attributes\Test]
+    public function anotherFakeTest(): void
+    {
+        self::assertTrue(true);
     }
 }

--- a/tests/e2e/forbids-class-attribute/skip-on-invalid-configuration-value.phpt
+++ b/tests/e2e/forbids-class-attribute/skip-on-invalid-configuration-value.phpt
@@ -1,0 +1,32 @@
+--TEST--
+Invalid configuration options are normalized to tests with unsatisfied requirements being skipped
+--FILE--
+<?php
+
+declare(strict_types=1);
+
+$_SERVER['argv'][] = '--do-not-cache-result';
+$_SERVER['argv'][] = '--display-skipped';
+$_SERVER['argv'][] = '--configuration';
+$_SERVER['argv'][] = __DIR__ . '/fixtures/skip-on-invalid-configuration-value/phpunit.xml';
+
+require dirname(__DIR__, 3) . '/vendor/autoload.php';
+
+(new \PHPUnit\TextUI\Application())->run($_SERVER['argv']);
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+Runtime: %s
+Configuration: %s
+
+S.                                                                  2 / 2 (100%)
+
+Time: %s, Memory: %s
+
+There was 1 skipped test:
+
+1) EliasHaeussler\PHPUnitAttributes\Tests\E2E\ForbidsClassAttributeSkipsOnInvalidConfigurationValueTest::fakeTest
+Class "Exception" is forbidden.
+
+OK, but some tests were skipped!
+Tests: 2, Assertions: 1, Skipped: 1.

--- a/tests/e2e/forbids-class-attribute/skip-on-unsatisfied-requirement.phpt
+++ b/tests/e2e/forbids-class-attribute/skip-on-unsatisfied-requirement.phpt
@@ -1,0 +1,32 @@
+--TEST--
+The #[ForbidsClass] attribute causes tests with unsatisified requirement to be skipped
+--FILE--
+<?php
+
+declare(strict_types=1);
+
+$_SERVER['argv'][] = '--do-not-cache-result';
+$_SERVER['argv'][] = '--display-skipped';
+$_SERVER['argv'][] = '--configuration';
+$_SERVER['argv'][] = __DIR__ . '/fixtures/skip-on-unsatisfied-requirement/phpunit.xml';
+
+require dirname(__DIR__, 3) . '/vendor/autoload.php';
+
+(new \PHPUnit\TextUI\Application())->run($_SERVER['argv']);
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+Runtime: %s
+Configuration: %s
+
+S.                                                                  2 / 2 (100%)
+
+Time: %s, Memory: %s
+
+There was 1 skipped test:
+
+1) EliasHaeussler\PHPUnitAttributes\Tests\E2E\ForbidsClassAttributeSkipsOnUnsatisfiedRequirementTest::fakeTest
+Class "Exception" is forbidden.
+
+OK, but some tests were skipped!
+Tests: 2, Assertions: 1, Skipped: 1.

--- a/tests/unit/Metadata/ClassRequirementsTest.php
+++ b/tests/unit/Metadata/ClassRequirementsTest.php
@@ -55,10 +55,30 @@ final class ClassRequirementsTest extends Framework\TestCase
         self::assertSame($expected, $this->subject->validateForAttribute($attribute));
     }
 
+    /**
+     * @param non-empty-string|null $message
+     */
+    #[Framework\Attributes\Test]
+    #[Framework\Attributes\DataProvider('validateForAttributeReturnsMessageIfClassExistsDataProvider')]
+    public function validateForAttributeReturnsMessageIfClassExists(?string $message, string $expected): void
+    {
+        $attribute = new Src\Attribute\ForbidsClass(self::class, $message);
+
+        self::assertSame($expected, $this->subject->validateForAttribute($attribute));
+    }
+
     #[Framework\Attributes\Test]
     public function validateForAttributeReturnsNullIfClassExists(): void
     {
         $attribute = new Src\Attribute\RequiresClass(self::class);
+
+        self::assertNull($this->subject->validateForAttribute($attribute));
+    }
+
+    #[Framework\Attributes\Test]
+    public function validateForAttributeReturnsNullIfClassDoesNotExist(): void
+    {
+        $attribute = new Src\Attribute\ForbidsClass('Foo\\Baz');
 
         self::assertNull($this->subject->validateForAttribute($attribute));
     }
@@ -70,5 +90,14 @@ final class ClassRequirementsTest extends Framework\TestCase
     {
         yield 'no message' => [null, Src\TextUI\Messages::forMissingClass('Foo\\Baz')];
         yield 'custom message' => ['Foo\\Baz is missing, sorry!', 'Foo\\Baz is missing, sorry!'];
+    }
+
+    /**
+     * @return Generator<string, array{non-empty-string|null, non-empty-string}>
+     */
+    public static function validateForAttributeReturnsMessageIfClassExistsDataProvider(): Generator
+    {
+        yield 'no message' => [null, Src\TextUI\Messages::forAvailableClass(self::class)];
+        yield 'custom message' => ['Class is available, sorry!', 'Class is available, sorry!'];
     }
 }


### PR DESCRIPTION
This pull request introduces the new `ForbidsClass` attribute to the PHPUnit Attributes library, allowing tests to be marked as executable only if a certain class does not exist. The most important changes include the addition of the `ForbidsClass` attribute, updates to the documentation, and the implementation of the necessary tracers and configuration.

### New Attribute Implementation:
* [`src/Attribute/ForbidsClass.php`](diffhunk://#diff-658adbf5de2dfe5d8c4232370b5435dfd653f25ac4b6af716c5eb669ce58843cR1-R68): Introduced the `ForbidsClass` attribute, which can be applied at the class or method level to forbid the presence of specific classes during test execution.

### Documentation Updates:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R67): Added `ForbidsClass` to the list of available attributes.
* [`docs/attributes/forbids-class.md`](diffhunk://#diff-81f4329321748de8929798f32cd0e3a446993ff4ff4cc5ecb8cdc2a1786e0b3fR1-R192): Created a new documentation file explaining the usage, configuration, and examples of the `ForbidsClass` attribute.

### Tracers and Configuration:
* [`src/Event/Tracer/ForbidsClassAttributeTracer.php`](diffhunk://#diff-c3984800857017a5bd284b2bd5f6b82b97a15ac0c48e83503e84dde0bcba2c1aR1-R66): Implemented the `ForbidsClassAttributeTracer` to handle the behavior of the `ForbidsClass` attribute.
* [`src/PHPUnitAttributesExtension.php`](diffhunk://#diff-7ad5f081b769fd33686cdf5b7f6ebd387b50914a4748ad2829bf3945a299f185L47-R157): Updated the extension to register the `ForbidsClass` attribute tracer and handle the new configuration parameters. [[1]](diffhunk://#diff-7ad5f081b769fd33686cdf5b7f6ebd387b50914a4748ad2829bf3945a299f185L47-R157) [[2]](diffhunk://#diff-7ad5f081b769fd33686cdf5b7f6ebd387b50914a4748ad2829bf3945a299f185L138-R176) [[3]](diffhunk://#diff-7ad5f081b769fd33686cdf5b7f6ebd387b50914a4748ad2829bf3945a299f185L154)

### Additional Enhancements:
* [`src/Metadata/ClassRequirements.php`](diffhunk://#diff-9e587a6d4f0c4ceb611a9a43fa64c85a1aa0766ec2a3d8762acfbc00428e6fc2L42-R55): Modified the `validateForAttribute` method to support the `ForbidsClass` attribute.
* [`src/TextUI/Messages.php`](diffhunk://#diff-f1785efbb8ad1abfff850af97e1be1b1e40f6b8b0b5c5e27517ce085b06d3257R66-R75): Added a new message for forbidden classes.

These changes enhance the flexibility and control over test execution based on the presence of specific classes, improving the robustness of the testing framework.