### PR TITLE
[FEATURE] Introduce `#[ForbidsPackage]` attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ The following attributes are shipped with this library:
 
 * [`#[ForbidsClass]`](docs/attributes/forbids-class.md)
 * [`#[ForbidsConstant]`](docs/attributes/forbids-constant.md)
+* [`#[ForbidsPackage]`](docs/attributes/forbids-package.md)
 * [`#[RequiresClass]`](docs/attributes/requires-class.md)
 * [`#[RequiresConstant]`](docs/attributes/requires-constant.md)
 * [`#[RequiresPackage]`](#requirespackage)

--- a/docs/attributes/forbids-package.md
+++ b/docs/attributes/forbids-package.md
@@ -1,11 +1,11 @@
-# [`#[RequiresPackage]`](../../src/Attribute/RequiresPackage.php)
+# [`#[ForbidsPackage]`](../../src/Attribute/ForbidsPackage.php)
 
 _Scope: Class & Method level_
 
-This attribute can be used to define specific package requirements for single
-tests as well as complete test classes. A required package is expected to be
-installed via Composer. You can optionally define a version constraint and a
-custom message.
+This attribute can be used to define packages which should *not* be
+installed via Composer in the current environment. It can be specified
+for single tests as well as complete test classes. You can optionally
+define a version constraint and a custom message.
 
 > [!IMPORTANT]
 > The attribute determines installed Composer packages from the build-time
@@ -26,15 +26,15 @@ custom message.
 
 ## Configuration
 
-By default, test cases with unsatisfied requirements are skipped. However, this
-behavior can be configured by using the `handleUnsatisfiedPackageRequirements`
-extension parameter. If set to `fail`, test cases with unsatisfied requirements
+By default, test cases with satisfied requirements are skipped. However, this
+behavior can be configured by using the `handleSatisfiedPackageRequirements`
+extension parameter. If set to `fail`, test cases with satisfied requirements
 will fail (defaults to `skip`):
 
 ```xml
 <extensions>
     <bootstrap class="EliasHaeussler\PHPUnitAttributes\PHPUnitAttributesExtension">
-        <parameter name="handleUnsatisfiedPackageRequirements" value="fail" />
+        <parameter name="handleSatisfiedPackageRequirements" value="fail" />
     </bootstrap>
 </extensions>
 ```
@@ -44,7 +44,7 @@ will fail (defaults to `skip`):
 ```php
 final class DummyTest extends TestCase
 {
-    #[RequiresPackage('symfony/console')]
+    #[ForbidsPackage('symfony/console')]
     public function testDummyAction(): void
     {
         // ...
@@ -55,22 +55,22 @@ final class DummyTest extends TestCase
 <details>
 <summary>More examples</summary>
 
-### Require explicit Composer package
+### Forbid explicit Composer package
 
 Class level:
 
 ```php
-#[RequiresPackage('symfony/console')]
+#[ForbidsPackage('symfony/console')]
 final class DummyTest extends TestCase
 {
     public function testDummyAction(): void
     {
-        // Skipped if symfony/console is not installed.
+        // Skipped if symfony/console is installed.
     }
 
     public function testOtherDummyAction(): void
     {
-        // Skipped if symfony/console is not installed.
+        // Skipped if symfony/console is installed.
     }
 }
 ```
@@ -80,10 +80,10 @@ Method level:
 ```php
 final class DummyTest extends TestCase
 {
-    #[RequiresPackage('symfony/console')]
+    #[ForbidsPackage('symfony/console')]
     public function testDummyAction(): void
     {
-        // Skipped if symfony/console is not installed.
+        // Skipped if symfony/console is installed.
     }
 
     public function testOtherDummyAction(): void
@@ -93,22 +93,22 @@ final class DummyTest extends TestCase
 }
 ```
 
-### Require any Composer package matching a given pattern
+### Forbid any Composer package matching a given pattern
 
 Class level:
 
 ```php
-#[RequiresPackage('symfony/*')]
+#[ForbidsPackage('symfony/*')]
 final class DummyTest extends TestCase
 {
     public function testDummyAction(): void
     {
-        // Skipped if no symfony/* packages are installed.
+        // Skipped if any symfony/* packages are installed.
     }
 
     public function testOtherDummyAction(): void
     {
-        // Skipped if no symfony/* packages are installed.
+        // Skipped if any symfony/* packages are installed.
     }
 }
 ```
@@ -118,10 +118,10 @@ Method level:
 ```php
 final class DummyTest extends TestCase
 {
-    #[RequiresPackage('symfony/*')]
+    #[ForbidsPackage('symfony/*')]
     public function testDummyAction(): void
     {
-        // Skipped if no symfony/* packages are installed.
+        // Skipped if any symfony/* packages are installed.
     }
 
     public function testOtherDummyAction(): void
@@ -131,22 +131,22 @@ final class DummyTest extends TestCase
 }
 ```
 
-### Require Composer package with given version constraint
+### Forbid Composer package with given version constraint
 
 Class level:
 
 ```php
-#[RequiresPackage('symfony/console', '>= 7')]
+#[ForbidsPackage('symfony/console', '>= 7')]
 final class DummyTest extends TestCase
 {
     public function testDummyAction(): void
     {
-        // Skipped if installed version of symfony/console is < 7.
+        // Skipped if installed version of symfony/console is >= 7.
     }
 
     public function testOtherDummyAction(): void
     {
-        // Skipped if installed version of symfony/console is < 7.
+        // Skipped if installed version of symfony/console is >= 7.
     }
 }
 ```
@@ -156,10 +156,10 @@ Method level:
 ```php
 final class DummyTest extends TestCase
 {
-    #[RequiresPackage('symfony/console', '>= 7')]
+    #[ForbidsPackage('symfony/console', '>= 7')]
     public function testDummyAction(): void
     {
-        // Skipped if installed version of symfony/console is < 7.
+        // Skipped if installed version of symfony/console is >= 7.
     }
 
     public function testOtherDummyAction(): void
@@ -169,22 +169,22 @@ final class DummyTest extends TestCase
 }
 ```
 
-### Require Composer package and provide custom message
+### Forbid Composer package and provide custom message
 
 Class level:
 
 ```php
-#[RequiresPackage('symfony/console', message: 'This test requires the Symfony Console.')]
+#[ForbidsPackage('symfony/console', message: 'This test forbids the Symfony Console.')]
 final class DummyTest extends TestCase
 {
     public function testDummyAction(): void
     {
-        // Skipped if symfony/console is not installed, along with custom message.
+        // Skipped if symfony/console is installed, along with custom message.
     }
 
     public function testOtherDummyAction(): void
     {
-        // Skipped if symfony/console is not installed, along with custom message.
+        // Skipped if symfony/console is installed, along with custom message.
     }
 }
 ```
@@ -194,10 +194,10 @@ Method level:
 ```php
 final class DummyTest extends TestCase
 {
-    #[RequiresPackage('symfony/console', message: 'This test requires the Symfony Console.')]
+    #[ForbidsPackage('symfony/console', message: 'This test forbids the Symfony Console.')]
     public function testDummyAction(): void
     {
-        // Skipped if symfony/console is not installed, along with custom message.
+        // Skipped if symfony/console is installed, along with custom message.
     }
 
     public function testOtherDummyAction(): void
@@ -207,22 +207,22 @@ final class DummyTest extends TestCase
 }
 ```
 
-### Require Composer package and define custom outcome behavior
+### Forbid Composer package and define custom outcome behavior
 
 Class level:
 
 ```php
-#[RequiresPackage('symfony/console', outcomeBehavior: OutcomeBehavior::Fail)]
+#[ForbidsPackage('symfony/console', outcomeBehavior: OutcomeBehavior::Fail)]
 final class DummyTest extends TestCase
 {
     public function testDummyAction(): void
     {
-        // Fails if symfony/console is not installed.
+        // Fails if symfony/console is installed.
     }
 
     public function testOtherDummyAction(): void
     {
-        // Fails if symfony/console is not installed.
+        // Fails if symfony/console is installed.
     }
 }
 ```
@@ -232,10 +232,10 @@ Method level:
 ```php
 final class DummyTest extends TestCase
 {
-    #[RequiresPackage('symfony/console', outcomeBehavior: OutcomeBehavior::Fail)]
+    #[ForbidsPackage('symfony/console', outcomeBehavior: OutcomeBehavior::Fail)]
     public function testDummyAction(): void
     {
-        // Fails if symfony/console is not installed.
+        // Fails if symfony/console is installed.
     }
 
     public function testOtherDummyAction(): void
@@ -250,18 +250,18 @@ final class DummyTest extends TestCase
 Class level:
 
 ```php
-#[RequiresPackage('symfony/console')]
-#[RequiresPackage('guzzlehttp/guzzle')]
+#[ForbidsPackage('symfony/console')]
+#[ForbidsPackage('guzzlehttp/guzzle')]
 final class DummyTest extends TestCase
 {
     public function testDummyAction(): void
     {
-        // Skipped if symfony/console and/or guzzlehttp/guzzle are not installed.
+        // Skipped if symfony/console and/or guzzlehttp/guzzle are installed.
     }
 
     public function testOtherDummyAction(): void
     {
-        // Skipped if symfony/console and/or guzzlehttp/guzzle are not installed.
+        // Skipped if symfony/console and/or guzzlehttp/guzzle are installed.
     }
 }
 ```
@@ -271,11 +271,11 @@ Method level:
 ```php
 final class DummyTest extends TestCase
 {
-    #[RequiresPackage('symfony/console')]
-    #[RequiresPackage('guzzlehttp/guzzle')]
+    #[ForbidsPackage('symfony/console')]
+    #[ForbidsPackage('guzzlehttp/guzzle')]
     public function testDummyAction(): void
     {
-        // Skipped if symfony/console and/or guzzlehttp/guzzle are not installed.
+        // Skipped if symfony/console and/or guzzlehttp/guzzle are installed.
     }
 
     public function testOtherDummyAction(): void

--- a/src/Attribute/ForbidsPackage.php
+++ b/src/Attribute/ForbidsPackage.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/phpunit-attributes".
+ *
+ * Copyright (C) 2024-2025 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\PHPUnitAttributes\Attribute;
+
+use Attribute;
+use EliasHaeussler\PHPUnitAttributes\Enum;
+
+/**
+ * ForbidsPackage.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ */
+#[Attribute(Attribute::TARGET_METHOD | Attribute::TARGET_CLASS | Attribute::IS_REPEATABLE)]
+final class ForbidsPackage
+{
+    /**
+     * @param non-empty-string      $package
+     * @param non-empty-string|null $versionRequirement
+     * @param non-empty-string|null $message
+     */
+    public function __construct(
+        private readonly string $package,
+        private readonly ?string $versionRequirement = null,
+        private readonly ?string $message = null,
+        private readonly ?Enum\OutcomeBehavior $outcomeBehavior = null,
+    ) {}
+
+    /**
+     * @return non-empty-string
+     */
+    public function package(): string
+    {
+        return $this->package;
+    }
+
+    /**
+     * @return non-empty-string|null
+     */
+    public function versionRequirement(): ?string
+    {
+        return $this->versionRequirement;
+    }
+
+    /**
+     * @return non-empty-string|null
+     */
+    public function message(): ?string
+    {
+        return $this->message;
+    }
+
+    public function outcomeBehavior(): ?Enum\OutcomeBehavior
+    {
+        return $this->outcomeBehavior;
+    }
+}

--- a/src/Event/Tracer/ForbidsPackageAttributeTracer.php
+++ b/src/Event/Tracer/ForbidsPackageAttributeTracer.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/phpunit-attributes".
+ *
+ * Copyright (C) 2024-2025 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\PHPUnitAttributes\Event\Tracer;
+
+use EliasHaeussler\PHPUnitAttributes\Attribute;
+use EliasHaeussler\PHPUnitAttributes\Enum;
+use EliasHaeussler\PHPUnitAttributes\Metadata;
+
+/**
+ * ForbidsPackageAttributeTracer.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ *
+ * @extends AbstractAttributeTracer<Attribute\ForbidsPackage>
+ */
+final class ForbidsPackageAttributeTracer extends AbstractAttributeTracer
+{
+    public function __construct(
+        private readonly Metadata\PackageRequirements $packageRequirements,
+        Enum\OutcomeBehavior $behaviorOnSatisfiedPackageRequirements,
+    ) {
+        $this->defaultOutcomeBehavior = $behaviorOnSatisfiedPackageRequirements;
+    }
+
+    protected function resolveBehaviorsFromAttributes(array $attributes): array
+    {
+        $notSatisfied = [];
+
+        foreach ($attributes as $attribute) {
+            $message = $this->packageRequirements->validateForAttribute($attribute);
+
+            if (null !== $message) {
+                $notSatisfied[$message] = $attribute->outcomeBehavior() ?? $this->defaultOutcomeBehavior;
+            }
+        }
+
+        return $notSatisfied;
+    }
+
+    protected function getAttributeClassName(): string
+    {
+        return Attribute\ForbidsPackage::class;
+    }
+}

--- a/src/PHPUnitAttributesExtension.php
+++ b/src/PHPUnitAttributesExtension.php
@@ -125,6 +125,14 @@ final class PHPUnitAttributesExtension implements Runner\Extension\Extension
             ),
         );
 
+        // ForbidsPackage
+        $facade->registerTracer(
+            new Event\Tracer\ForbidsPackageAttributeTracer(
+                new Metadata\PackageRequirements(),
+                $this->resolveOutcomeBehavior('handleSatisfiedPackageRequirements', $parameters),
+            ),
+        );
+
         return $migrationResult;
     }
 

--- a/src/TextUI/Messages.php
+++ b/src/TextUI/Messages.php
@@ -41,12 +41,29 @@ final class Messages
      *
      * @return non-empty-string
      */
-    public static function forMissingRequiredPackage(
+    public static function forMissingPackage(
         string $packageName,
         ?Metadata\Version\Requirement $versionRequirement = null,
     ): string {
         return sprintf(
             '%s "%s"%s is required.',
+            str_contains($packageName, '*') ? 'Any package matching' : 'Package',
+            $packageName,
+            null !== $versionRequirement ? ' ('.$versionRequirement->asString().')' : '',
+        );
+    }
+
+    /**
+     * @param non-empty-string $packageName
+     *
+     * @return non-empty-string
+     */
+    public static function forInstalledPackage(
+        string $packageName,
+        ?Metadata\Version\Requirement $versionRequirement = null,
+    ): string {
+        return sprintf(
+            '%s "%s"%s is forbidden.',
             str_contains($packageName, '*') ? 'Any package matching' : 'Package',
             $packageName,
             null !== $versionRequirement ? ' ('.$versionRequirement->asString().')' : '',

--- a/tests/e2e/forbids-package-attribute/custom-message.phpt
+++ b/tests/e2e/forbids-package-attribute/custom-message.phpt
@@ -1,0 +1,32 @@
+--TEST--
+The #[ForbidsPackage] attribute is applied with custom message
+--FILE--
+<?php
+
+declare(strict_types=1);
+
+$_SERVER['argv'][] = '--do-not-cache-result';
+$_SERVER['argv'][] = '--display-skipped';
+$_SERVER['argv'][] = '--configuration';
+$_SERVER['argv'][] = __DIR__ . '/fixtures/custom-message/phpunit.xml';
+
+require dirname(__DIR__, 3) . '/vendor/autoload.php';
+
+(new \PHPUnit\TextUI\Application())->run($_SERVER['argv']);
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+Runtime: %s
+Configuration: %s
+
+S                                                                   1 / 1 (100%)
+
+Time: %s, Memory: %s
+
+There was 1 skipped test:
+
+1) EliasHaeussler\PHPUnitAttributes\Tests\E2E\ForbidsPackageAttributeWithCustomMessageTest::fakeTest
+PHPUnit >= 10 must not be installed
+
+OK, but some tests were skipped!
+Tests: 1, Assertions: 0, Skipped: 1.

--- a/tests/e2e/forbids-package-attribute/fail-on-satisfied-requirement.phpt
+++ b/tests/e2e/forbids-package-attribute/fail-on-satisfied-requirement.phpt
@@ -1,0 +1,35 @@
+--TEST--
+The #[ForbidsPackage] attribute causes tests with satisified requirement to fail
+--FILE--
+<?php
+
+declare(strict_types=1);
+
+$_SERVER['argv'][] = '--do-not-cache-result';
+$_SERVER['argv'][] = '--configuration';
+$_SERVER['argv'][] = __DIR__ . '/fixtures/fail-on-unsatisfied-requirement/phpunit.xml';
+
+require dirname(__DIR__, 3) . '/vendor/autoload.php';
+
+(new \PHPUnit\TextUI\Application())->run($_SERVER['argv']);
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+Runtime: %s
+Configuration: %s
+
+F.                                                                  2 / 2 (100%)
+
+Time: %s, Memory: %s
+
+There was 1 failure:
+
+1) EliasHaeussler\PHPUnitAttributes\Tests\E2E\ForbidsPackageAttributeFailsOnSatisfiedRequirementTest::fakeTest
+Package "phpunit/phpunit" is forbidden.
+
+%s
+%s
+%s
+
+FAILURES!
+Tests: 2, Assertions: 2, Failures: 1.

--- a/tests/e2e/forbids-package-attribute/fixtures/custom-message/phpunit.xml
+++ b/tests/e2e/forbids-package-attribute/fixtures/custom-message/phpunit.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="../../../../../vendor/phpunit/phpunit/phpunit.xsd"
+>
+    <extensions>
+        <bootstrap class="EliasHaeussler\PHPUnitAttributes\PHPUnitAttributesExtension" />
+    </extensions>
+    <testsuites>
+        <testsuite name="default">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/tests/e2e/forbids-package-attribute/fixtures/custom-message/tests/ForbidsPackageAttributeWithCustomMessageTest.php
+++ b/tests/e2e/forbids-package-attribute/fixtures/custom-message/tests/ForbidsPackageAttributeWithCustomMessageTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/phpunit-attributes".
+ *
+ * Copyright (C) 2024-2025 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\PHPUnitAttributes\Tests\E2E;
+
+use EliasHaeussler\PHPUnitAttributes as Src;
+use PHPUnit\Framework;
+
+/**
+ * ForbidsPackageAttributeWithCustomMessageTest.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ */
+final class ForbidsPackageAttributeWithCustomMessageTest extends Framework\TestCase
+{
+    #[Framework\Attributes\Test]
+    #[Src\Attribute\ForbidsPackage('phpunit/phpunit', '>= 10', 'PHPUnit >= 10 must not be installed')]
+    public function fakeTest(): void
+    {
+        self::assertTrue(true);
+    }
+}

--- a/tests/e2e/forbids-package-attribute/fixtures/fail-on-unsatisfied-requirement/phpunit.xml
+++ b/tests/e2e/forbids-package-attribute/fixtures/fail-on-unsatisfied-requirement/phpunit.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="../../../../../vendor/phpunit/phpunit/phpunit.xsd"
+>
+    <extensions>
+        <bootstrap class="EliasHaeussler\PHPUnitAttributes\PHPUnitAttributesExtension">
+            <parameter name="handleSatisfiedPackageRequirements" value="fail" />
+        </bootstrap>
+    </extensions>
+    <testsuites>
+        <testsuite name="default">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/tests/e2e/forbids-package-attribute/fixtures/fail-on-unsatisfied-requirement/tests/ForbidsPackageAttributeFailsOnSatisfiedRequirementTest.php
+++ b/tests/e2e/forbids-package-attribute/fixtures/fail-on-unsatisfied-requirement/tests/ForbidsPackageAttributeFailsOnSatisfiedRequirementTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/phpunit-attributes".
+ *
+ * Copyright (C) 2024-2025 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\PHPUnitAttributes\Tests\E2E;
+
+use EliasHaeussler\PHPUnitAttributes as Src;
+use PHPUnit\Framework;
+
+/**
+ * ForbidsPackageAttributeFailsOnSatisfiedRequirementTest.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ */
+final class ForbidsPackageAttributeFailsOnSatisfiedRequirementTest extends Framework\TestCase
+{
+    #[Framework\Attributes\Test]
+    #[Src\Attribute\ForbidsPackage('phpunit/phpunit')]
+    public function fakeTest(): void
+    {
+        self::assertTrue(true);
+    }
+
+    #[Framework\Attributes\Test]
+    public function anotherFakeTest(): void
+    {
+        self::assertTrue(true);
+    }
+}

--- a/tests/e2e/forbids-package-attribute/fixtures/no-version-requirement/phpunit.xml
+++ b/tests/e2e/forbids-package-attribute/fixtures/no-version-requirement/phpunit.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="../../../../../vendor/phpunit/phpunit/phpunit.xsd"
+>
+    <extensions>
+        <bootstrap class="EliasHaeussler\PHPUnitAttributes\PHPUnitAttributesExtension" />
+    </extensions>
+    <testsuites>
+        <testsuite name="default">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/tests/e2e/forbids-package-attribute/fixtures/no-version-requirement/tests/ForbidsPackageAttributeWithoutVersionRequirementTest.php
+++ b/tests/e2e/forbids-package-attribute/fixtures/no-version-requirement/tests/ForbidsPackageAttributeWithoutVersionRequirementTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/phpunit-attributes".
+ *
+ * Copyright (C) 2024-2025 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\PHPUnitAttributes\Tests\E2E;
+
+use EliasHaeussler\PHPUnitAttributes as Src;
+use PHPUnit\Framework;
+
+/**
+ * ForbidsPackageAttributeWithoutVersionRequirementTest.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ */
+final class ForbidsPackageAttributeWithoutVersionRequirementTest extends Framework\TestCase
+{
+    #[Framework\Attributes\Test]
+    #[Src\Attribute\ForbidsPackage('phpunit/phpunit')]
+    public function fakeTest(): void
+    {
+        self::assertTrue(true);
+    }
+
+    #[Framework\Attributes\Test]
+    #[Src\Attribute\ForbidsPackage('foo/baz')]
+    public function anotherFakeTest(): void
+    {
+        self::assertTrue(true);
+    }
+}

--- a/tests/e2e/forbids-package-attribute/fixtures/package-pattern/phpunit.xml
+++ b/tests/e2e/forbids-package-attribute/fixtures/package-pattern/phpunit.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="../../../../../vendor/phpunit/phpunit/phpunit.xsd"
+>
+    <extensions>
+        <bootstrap class="EliasHaeussler\PHPUnitAttributes\PHPUnitAttributesExtension" />
+    </extensions>
+    <testsuites>
+        <testsuite name="default">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/tests/e2e/forbids-package-attribute/fixtures/package-pattern/tests/ForbidsPackageAttributeWithPackagePatternTest.php
+++ b/tests/e2e/forbids-package-attribute/fixtures/package-pattern/tests/ForbidsPackageAttributeWithPackagePatternTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/phpunit-attributes".
+ *
+ * Copyright (C) 2024-2025 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\PHPUnitAttributes\Tests\E2E;
+
+use EliasHaeussler\PHPUnitAttributes as Src;
+use PHPUnit\Framework;
+
+/**
+ * ForbidsPackageAttributeWithPackagePatternTest.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ */
+final class ForbidsPackageAttributeWithPackagePatternTest extends Framework\TestCase
+{
+    #[Framework\Attributes\Test]
+    #[Src\Attribute\ForbidsPackage('phpunit/*-coverage', '>= 10')]
+    public function fakeTest(): void
+    {
+        self::assertTrue(true);
+    }
+
+    #[Framework\Attributes\Test]
+    #[Src\Attribute\ForbidsPackage('phpunit/*')]
+    public function anotherFakeTest(): void
+    {
+        self::assertTrue(true);
+    }
+}

--- a/tests/e2e/forbids-package-attribute/fixtures/skip-on-invalid-configuration-value/phpunit.xml
+++ b/tests/e2e/forbids-package-attribute/fixtures/skip-on-invalid-configuration-value/phpunit.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="../../../../../vendor/phpunit/phpunit/phpunit.xsd"
+>
+    <extensions>
+        <bootstrap class="EliasHaeussler\PHPUnitAttributes\PHPUnitAttributesExtension">
+            <!-- "foo" is invalid here by purpose, test verifies that it's normalized to ”skip" -->
+            <parameter name="handleSatisfiedPackageRequirements" value="foo" />
+        </bootstrap>
+    </extensions>
+    <testsuites>
+        <testsuite name="default">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/tests/e2e/forbids-package-attribute/fixtures/skip-on-invalid-configuration-value/tests/ForbidsPackageAttributeSkipsOnInvalidConfigurationValueTest.php
+++ b/tests/e2e/forbids-package-attribute/fixtures/skip-on-invalid-configuration-value/tests/ForbidsPackageAttributeSkipsOnInvalidConfigurationValueTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/phpunit-attributes".
+ *
+ * Copyright (C) 2024-2025 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\PHPUnitAttributes\Tests\E2E;
+
+use EliasHaeussler\PHPUnitAttributes as Src;
+use PHPUnit\Framework;
+
+/**
+ * ForbidsPackageAttributeSkipsOnInvalidConfigurationValueTest.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ */
+final class ForbidsPackageAttributeSkipsOnInvalidConfigurationValueTest extends Framework\TestCase
+{
+    #[Framework\Attributes\Test]
+    #[Src\Attribute\ForbidsPackage('phpunit/phpunit')]
+    public function fakeTest(): void
+    {
+        self::assertTrue(true);
+    }
+
+    #[Framework\Attributes\Test]
+    public function anotherFakeTest(): void
+    {
+        self::assertTrue(true);
+    }
+}

--- a/tests/e2e/forbids-package-attribute/fixtures/skip-on-satisfied-requirement/phpunit.xml
+++ b/tests/e2e/forbids-package-attribute/fixtures/skip-on-satisfied-requirement/phpunit.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="../../../../../vendor/phpunit/phpunit/phpunit.xsd"
+>
+    <extensions>
+        <bootstrap class="EliasHaeussler\PHPUnitAttributes\PHPUnitAttributesExtension">
+            <parameter name="handleSatisfiedPackageRequirements" value="skip" />
+        </bootstrap>
+    </extensions>
+    <testsuites>
+        <testsuite name="default">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/tests/e2e/forbids-package-attribute/fixtures/skip-on-satisfied-requirement/tests/ForbidsPackageAttributeSkipsOnSatisfiedRequirementTest.php
+++ b/tests/e2e/forbids-package-attribute/fixtures/skip-on-satisfied-requirement/tests/ForbidsPackageAttributeSkipsOnSatisfiedRequirementTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/phpunit-attributes".
+ *
+ * Copyright (C) 2024-2025 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\PHPUnitAttributes\Tests\E2E;
+
+use EliasHaeussler\PHPUnitAttributes as Src;
+use PHPUnit\Framework;
+
+/**
+ * ForbidsPackageAttributeSkipsOnSatisfiedRequirementTest.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ */
+final class ForbidsPackageAttributeSkipsOnSatisfiedRequirementTest extends Framework\TestCase
+{
+    #[Framework\Attributes\Test]
+    #[Src\Attribute\ForbidsPackage('phpunit/phpunit')]
+    public function fakeTest(): void
+    {
+        self::assertTrue(true);
+    }
+
+    #[Framework\Attributes\Test]
+    public function anotherFakeTest(): void
+    {
+        self::assertTrue(true);
+    }
+}

--- a/tests/e2e/forbids-package-attribute/no-version-requirement.phpt
+++ b/tests/e2e/forbids-package-attribute/no-version-requirement.phpt
@@ -1,0 +1,32 @@
+--TEST--
+The #[ForbidsPackage] attribute is applied without version requirement
+--FILE--
+<?php
+
+declare(strict_types=1);
+
+$_SERVER['argv'][] = '--do-not-cache-result';
+$_SERVER['argv'][] = '--display-skipped';
+$_SERVER['argv'][] = '--configuration';
+$_SERVER['argv'][] = __DIR__ . '/fixtures/no-version-requirement/phpunit.xml';
+
+require dirname(__DIR__, 3) . '/vendor/autoload.php';
+
+(new \PHPUnit\TextUI\Application())->run($_SERVER['argv']);
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+Runtime: %s
+Configuration: %s
+
+S.                                                                  2 / 2 (100%)
+
+Time: %s, Memory: %s
+
+There was 1 skipped test:
+
+1) EliasHaeussler\PHPUnitAttributes\Tests\E2E\ForbidsPackageAttributeWithoutVersionRequirementTest::fakeTest
+Package "phpunit/phpunit" is forbidden.
+
+OK, but some tests were skipped!
+Tests: 2, Assertions: 1, Skipped: 1.

--- a/tests/e2e/forbids-package-attribute/package-pattern.phpt
+++ b/tests/e2e/forbids-package-attribute/package-pattern.phpt
@@ -1,0 +1,35 @@
+--TEST--
+The #[ForbidsPackage] attribute supports patterns for forbidden packages
+--FILE--
+<?php
+
+declare(strict_types=1);
+
+$_SERVER['argv'][] = '--do-not-cache-result';
+$_SERVER['argv'][] = '--display-skipped';
+$_SERVER['argv'][] = '--configuration';
+$_SERVER['argv'][] = __DIR__ . '/fixtures/package-pattern/phpunit.xml';
+
+require dirname(__DIR__, 3) . '/vendor/autoload.php';
+
+(new \PHPUnit\TextUI\Application())->run($_SERVER['argv']);
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+Runtime: %s
+Configuration: %s
+
+SS                                                                  2 / 2 (100%)
+
+Time: %s, Memory: %s
+
+There were 2 skipped tests:
+
+1) EliasHaeussler\PHPUnitAttributes\Tests\E2E\ForbidsPackageAttributeWithPackagePatternTest::fakeTest
+Package "phpunit/php-code-coverage" (>= 10) is forbidden.
+
+2) EliasHaeussler\PHPUnitAttributes\Tests\E2E\ForbidsPackageAttributeWithPackagePatternTest::anotherFakeTest
+Any package matching "phpunit/*" is forbidden.
+
+OK, but some tests were skipped!
+Tests: 2, Assertions: 0, Skipped: 2.

--- a/tests/e2e/forbids-package-attribute/skip-on-invalid-configuration-value.phpt
+++ b/tests/e2e/forbids-package-attribute/skip-on-invalid-configuration-value.phpt
@@ -1,0 +1,32 @@
+--TEST--
+Invalid configuration options are normalized to tests with satisfied requirements being skipped
+--FILE--
+<?php
+
+declare(strict_types=1);
+
+$_SERVER['argv'][] = '--do-not-cache-result';
+$_SERVER['argv'][] = '--display-skipped';
+$_SERVER['argv'][] = '--configuration';
+$_SERVER['argv'][] = __DIR__ . '/fixtures/skip-on-invalid-configuration-value/phpunit.xml';
+
+require dirname(__DIR__, 3) . '/vendor/autoload.php';
+
+(new \PHPUnit\TextUI\Application())->run($_SERVER['argv']);
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+Runtime: %s
+Configuration: %s
+
+S.                                                                  2 / 2 (100%)
+
+Time: %s, Memory: %s
+
+There was 1 skipped test:
+
+1) EliasHaeussler\PHPUnitAttributes\Tests\E2E\ForbidsPackageAttributeSkipsOnInvalidConfigurationValueTest::fakeTest
+Package "phpunit/phpunit" is forbidden.
+
+OK, but some tests were skipped!
+Tests: 2, Assertions: 1, Skipped: 1.

--- a/tests/e2e/forbids-package-attribute/skip-on-satisfied-requirement.phpt
+++ b/tests/e2e/forbids-package-attribute/skip-on-satisfied-requirement.phpt
@@ -1,0 +1,32 @@
+--TEST--
+The #[ForbidsPackage] attribute causes tests with satisified requirement to be skipped
+--FILE--
+<?php
+
+declare(strict_types=1);
+
+$_SERVER['argv'][] = '--do-not-cache-result';
+$_SERVER['argv'][] = '--display-skipped';
+$_SERVER['argv'][] = '--configuration';
+$_SERVER['argv'][] = __DIR__ . '/fixtures/skip-on-satisfied-requirement/phpunit.xml';
+
+require dirname(__DIR__, 3) . '/vendor/autoload.php';
+
+(new \PHPUnit\TextUI\Application())->run($_SERVER['argv']);
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+Runtime: %s
+Configuration: %s
+
+S.                                                                  2 / 2 (100%)
+
+Time: %s, Memory: %s
+
+There was 1 skipped test:
+
+1) EliasHaeussler\PHPUnitAttributes\Tests\E2E\ForbidsPackageAttributeSkipsOnSatisfiedRequirementTest::fakeTest
+Package "phpunit/phpunit" is forbidden.
+
+OK, but some tests were skipped!
+Tests: 2, Assertions: 1, Skipped: 1.

--- a/tests/unit/TextUI/MessagesTest.php
+++ b/tests/unit/TextUI/MessagesTest.php
@@ -37,22 +37,42 @@ use PHPUnit\Metadata\Version\ConstraintRequirement;
 final class MessagesTest extends Framework\TestCase
 {
     #[Framework\Attributes\Test]
-    public function forMissingRequiredPackageReturnMessageForGivenPackage(): void
+    public function forMissingPackageReturnMessageForGivenPackage(): void
     {
         self::assertSame(
             'Package "foo/baz" is required.',
-            Src\TextUI\Messages::forMissingRequiredPackage('foo/baz'),
+            Src\TextUI\Messages::forMissingPackage('foo/baz'),
         );
     }
 
     #[Framework\Attributes\Test]
-    public function forMissingRequiredPackageReturnMessageForGivenPackageAndVersionRequirement(): void
+    public function forMissingPackageReturnMessageForGivenPackageAndVersionRequirement(): void
     {
         $versionRequirement = ConstraintRequirement::from('> 10');
 
         self::assertSame(
             'Package "foo/baz" (> 10) is required.',
-            Src\TextUI\Messages::forMissingRequiredPackage('foo/baz', $versionRequirement),
+            Src\TextUI\Messages::forMissingPackage('foo/baz', $versionRequirement),
+        );
+    }
+
+    #[Framework\Attributes\Test]
+    public function forInstalledPackageReturnMessageForGivenPackage(): void
+    {
+        self::assertSame(
+            'Package "phpunit/phpunit" is forbidden.',
+            Src\TextUI\Messages::forInstalledPackage('phpunit/phpunit'),
+        );
+    }
+
+    #[Framework\Attributes\Test]
+    public function forInstalledPackageReturnMessageForGivenPackageAndVersionRequirement(): void
+    {
+        $versionRequirement = ConstraintRequirement::from('> 10');
+
+        self::assertSame(
+            'Package "phpunit/phpunit" (> 10) is forbidden.',
+            Src\TextUI\Messages::forInstalledPackage('phpunit/phpunit', $versionRequirement),
         );
     }
 


### PR DESCRIPTION
This pull request introduces a new attribute `ForbidsPackage` to the `eliashaeussler/phpunit-attributes` package. This attribute allows users to specify Composer packages that should not be installed in the current environment for specific tests or test classes. The changes include the implementation of the attribute, documentation, and related tests.

### Attribute Implementation:
* [`src/Attribute/ForbidsPackage.php`](diffhunk://#diff-7eae76c7ffd571ab5ab4a65d4c93e2a6511bc14a0e3e88c26468c3f2ba078fabR1-R78): Introduced the `ForbidsPackage` attribute to forbid specific Composer packages with optional version constraints and custom messages.
* [`src/Event/Tracer/ForbidsPackageAttributeTracer.php`](diffhunk://#diff-6dab078d350c8de9afc872fd30ac369a18cbf925b4ec8d22ca188873dc0da6a4R1-R66): Added a tracer to handle the `ForbidsPackage` attribute, resolving behaviors based on the attribute's settings.

### Documentation:
* [`docs/attributes/forbids-package.md`](diffhunk://#diff-f91ae071c74c4a0f05087bcd4e491bc5031cc7efa194007a42f22f2cbf54dd86R1-R288): Added comprehensive documentation for the `ForbidsPackage` attribute, including its scope, configuration, and usage examples.

### Codebase Adjustments:
* [`src/Metadata/PackageRequirements.php`](diffhunk://#diff-8ef7009167dddda6b8ad97decdead6a1bbc8fc0445335e4d0e2d47fef29a7583L46-R80): Modified the `validateForAttribute` method to handle the `ForbidsPackage` attribute and adjusted package finding logic to support patterns. [[1]](diffhunk://#diff-8ef7009167dddda6b8ad97decdead6a1bbc8fc0445335e4d0e2d47fef29a7583L46-R80) [[2]](diffhunk://#diff-8ef7009167dddda6b8ad97decdead6a1bbc8fc0445335e4d0e2d47fef29a7583L72-R105)
* [`src/TextUI/Messages.php`](diffhunk://#diff-f1785efbb8ad1abfff850af97e1be1b1e40f6b8b0b5c5e27517ce085b06d3257L44-R44): Added a new method `forInstalledPackage` to generate messages for forbidden packages. [[1]](diffhunk://#diff-f1785efbb8ad1abfff850af97e1be1b1e40f6b8b0b5c5e27517ce085b06d3257L44-R44) [[2]](diffhunk://#diff-f1785efbb8ad1abfff850af97e1be1b1e40f6b8b0b5c5e27517ce085b06d3257R56-R72)
* [`src/PHPUnitAttributesExtension.php`](diffhunk://#diff-7ad5f081b769fd33686cdf5b7f6ebd387b50914a4748ad2829bf3945a299f185R128-R135): Registered the `ForbidsPackageAttributeTracer` in the PHPUnit extension.

### Tests:
* [`tests/e2e/forbids-package-attribute/custom-message.phpt`](diffhunk://#diff-607890fad73db709742db7bda4dfd47abcb3a00b285992fb50a296bec8c34fb2R1-R32): Added an end-to-end test to verify the custom message functionality of the `ForbidsPackage` attribute.
* [`tests/e2e/forbids-package-attribute/fail-on-satisfied-requirement.phpt`](diffhunk://#diff-2fba1f793c3b973efa67ef46d39f758b0e2ab70e546dbd17d49194e1db9f348fR1-R35): Added an end-to-end test to verify that tests fail when the forbidden package requirement is satisfied.
* [`tests/e2e/forbids-package-attribute/fixtures/custom-message/tests/ForbidsPackageAttributeWithCustomMessageTest.php`](diffhunk://#diff-0d6ccd896acd71e8610b53edb763862264293375273cf584c5ec472fe90acac8R1-R43): Implemented a test class to validate the custom message feature.
* [`tests/e2e/forbids-package-attribute/fixtures/custom-message/phpunit.xml`](diffhunk://#diff-9676ff653f0dc49a9bc2cb83b65c63bc55290fe89994179dbfb89e88c8430195R1-R13): Configuration for the custom message test.
* [`tests/e2e/forbids-package-attribute/fixtures/fail-on-unsatisfied-requirement/phpunit.xml`](diffhunk://#diff-15b6960cc52ff1dd7ce63868643e1a67212168bfca3e7ceafc90054c87184d30R1-R15): Configuration for the fail-on-satisfied-requirement test.