### PR TITLE
[FEATURE] Introduce `#[RequiresEnv]` and `#[ForbidsEnv]` attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,12 @@ The following attributes are shipped with this library:
 ### Composer package
 
 * [`#[ForbidsPackage]`](docs/attributes/forbids-package.md)
-* [`#[RequiresPackage]`](#requirespackage)
+* [`#[RequiresPackage]`](docs/attributes/requires-package.md)
+
+### Environment
+
+* [`#[ForbidsEnv]`](docs/attributes/forbids-env.md)
+* [`#[RequiresEnv]`](docs/attributes/requires-env.md)
 
 ## 🧑‍💻 Contributing
 

--- a/docs/attributes/forbids-class.md
+++ b/docs/attributes/forbids-class.md
@@ -7,7 +7,7 @@ if a certain class does *not* exist.
 
 ## Configuration
 
-By default, test cases requiring existent classes are skipped. However, this
+By default, test cases forbidding existent classes are skipped. However, this
 behavior can be configured by using the `handleAvailableClasses` extension parameter.
 If set to `fail`, test cases with available classes will fail (defaults to `skip`):
 
@@ -98,7 +98,7 @@ Method level:
 ```php
 final class DummyTest extends TestCase
 {
-    #[ForbidsClass('AnAbsentClass', 'This test requires the `AnAbsentClass` class.')]
+    #[ForbidsClass('AnAbsentClass', 'This test forbids the `AnAbsentClass` class.')]
     public function testDummyAction(): void
     {
         // Skipped if AnAbsentClass is available, along with custom message.

--- a/docs/attributes/forbids-constant.md
+++ b/docs/attributes/forbids-constant.md
@@ -9,7 +9,7 @@ current class loader (which normally is Composer's default class loader).
 
 ## Configuration
 
-By default, test cases requiring defined constants are skipped. However, this
+By default, test cases forbidding defined constants are skipped. However, this
 behavior can be configured by using the `handleDefinedConstants` extension
 parameter. If set to `fail`, test cases with defined constants will fail
 (defaults to `skip`):
@@ -81,7 +81,7 @@ final class DummyTest extends TestCase
 Class level:
 
 ```php
-#[ForbidsConstant(AnAnnoyingClass::class . '::AN_ANNOYING_CONSTANT', 'This test forbids an important constant.')]
+#[ForbidsConstant(AnAnnoyingClass::class . '::AN_ANNOYING_CONSTANT', 'This test forbids an annoying constant.')]
 final class DummyTest extends TestCase
 {
     public function testDummyAction(): void
@@ -101,7 +101,7 @@ Method level:
 ```php
 final class DummyTest extends TestCase
 {
-    #[ForbidsConstant(AnAnnoyingClass::class . '::AN_ANNOYING_CONSTANT', 'This test requires an important constant.')]
+    #[ForbidsConstant(AnAnnoyingClass::class . '::AN_ANNOYING_CONSTANT', 'This test forbids an annoying constant.')]
     public function testDummyAction(): void
     {
         // Skipped if AnAnnoyingClass::AN_ANNOYING_CONSTANT is defined, along with custom message.
@@ -157,18 +157,18 @@ final class DummyTest extends TestCase
 Class level:
 
 ```php
-#[ForbidsConstant('SOME_IMPORTANT_CONSTANT')]
-#[ForbidsConstant('ANOTHER_VERY_IMPORTANT_CONSTANT')]
+#[ForbidsConstant('SOME_ANNOYING_CONSTANT')]
+#[ForbidsConstant('ANOTHER_VERY_ANNOYING_CONSTANT')]
 final class DummyTest extends TestCase
 {
     public function testDummyAction(): void
     {
-        // Skipped if SOME_IMPORTANT_CONSTANT and/or ANOTHER_VERY_IMPORTANT_CONSTANT constants are defined.
+        // Skipped if SOME_ANNOYING_CONSTANT and/or ANOTHER_VERY_ANNOYING_CONSTANT constants are defined.
     }
 
     public function testOtherDummyAction(): void
     {
-        // Skipped if SOME_IMPORTANT_CONSTANT and/or ANOTHER_VERY_IMPORTANT_CONSTANT constants are defined.
+        // Skipped if SOME_ANNOYING_CONSTANT and/or ANOTHER_VERY_ANNOYING_CONSTANT constants are defined.
     }
 }
 ```
@@ -178,11 +178,11 @@ Method level:
 ```php
 final class DummyTest extends TestCase
 {
-    #[ForbidsConstant('SOME_IMPORTANT_CONSTANT')]
-    #[ForbidsConstant('ANOTHER_VERY_IMPORTANT_CONSTANT')]
+    #[ForbidsConstant('SOME_ANNOYING_CONSTANT')]
+    #[ForbidsConstant('ANOTHER_VERY_ANNOYING_CONSTANT')]
     public function testDummyAction(): void
     {
-        // Skipped if SOME_IMPORTANT_CONSTANT and/or ANOTHER_VERY_IMPORTANT_CONSTANT constants are defined.
+        // Skipped if SOME_ANNOYING_CONSTANT and/or ANOTHER_VERY_ANNOYING_CONSTANT constants are defined.
     }
 
     public function testOtherDummyAction(): void

--- a/docs/attributes/forbids-env.md
+++ b/docs/attributes/forbids-env.md
@@ -1,0 +1,196 @@
+# [`#[ForbidsEnv]`](../../src/Attribute/ForbidsEnv.php)
+
+_Scope: Class & Method level_
+
+With this attribute, tests or test cases can be marked as to be only executed
+if a certain environment variable does *not* exist. The environment variable
+is checked using [`getenv`](https://www.php.net/manual/en/function.getenv.php)
+and via the [`$_ENV`](https://www.php.net/manual/en/reserved.variables.environment.php)
+superglobal.
+
+## Configuration
+
+By default, test cases forbidding environment variables are skipped. However,
+this behavior can be configured by using the `handleAvailableEnvironmentVariables`
+extension parameter. If set to `fail`, test cases with available environment
+variables will fail (defaults to `skip`):
+
+```xml
+<extensions>
+    <bootstrap class="EliasHaeussler\PHPUnitAttributes\PHPUnitAttributesExtension">
+        <parameter name="handleAvailableEnvironmentVariables" value="fail" />
+    </bootstrap>
+</extensions>
+```
+
+## Example
+
+```php
+final class DummyTest extends TestCase
+{
+    #[ForbidsEnv('AN_ANNOYING_ENV')]
+    public function testDummyAction(): void
+    {
+        // ...
+    }
+}
+```
+
+<details>
+<summary>More examples</summary>
+
+### Forbid single environment variable
+
+Class level:
+
+```php
+#[ForbidsEnv('AN_ANNOYING_ENV')]
+final class DummyTest extends TestCase
+{
+    public function testDummyAction(): void
+    {
+        // Skipped if AN_ANNOYING_ENV is available.
+    }
+
+    public function testOtherDummyAction(): void
+    {
+        // Skipped if AN_ANNOYING_ENV is available.
+    }
+}
+```
+
+Method level:
+
+```php
+final class DummyTest extends TestCase
+{
+    #[ForbidsEnv('AN_ANNOYING_ENV')]
+    public function testDummyAction(): void
+    {
+        // Skipped if AN_ANNOYING_ENV is available.
+    }
+
+    public function testOtherDummyAction(): void
+    {
+        // Not skipped.
+    }
+}
+```
+
+### Forbid single environment variable and provide custom message
+
+Class level:
+
+```php
+#[ForbidsEnv('AN_ANNOYING_ENV', 'This test forbids an annoying env var.')]
+final class DummyTest extends TestCase
+{
+    public function testDummyAction(): void
+    {
+        // Skipped if AN_ANNOYING_ENV is available, along with custom message.
+    }
+
+    public function testOtherDummyAction(): void
+    {
+        // Skipped if AN_ANNOYING_ENV is available, along with custom message.
+    }
+}
+```
+
+Method level:
+
+```php
+final class DummyTest extends TestCase
+{
+    #[ForbidsEnv('AN_ANNOYING_ENV', 'This test forbids an annoying env var.')]
+    public function testDummyAction(): void
+    {
+        // Skipped if AN_ANNOYING_ENV is available, along with custom message.
+    }
+
+    public function testOtherDummyAction(): void
+    {
+        // Not skipped.
+    }
+}
+```
+
+### Forbid single environment variable and define custom outcome behavior
+
+Class level:
+
+```php
+#[ForbidsEnv('AN_ANNOYING_ENV', outcomeBehavior: OutcomeBehavior::Fail)]
+final class DummyTest extends TestCase
+{
+    public function testDummyAction(): void
+    {
+        // Fails if AN_ANNOYING_ENV is available.
+    }
+
+    public function testOtherDummyAction(): void
+    {
+        // Fails if AN_ANNOYING_ENV is available.
+    }
+}
+```
+
+Method level:
+
+```php
+final class DummyTest extends TestCase
+{
+    #[ForbidsEnv('AN_ANNOYING_ENV', outcomeBehavior: OutcomeBehavior::Fail)]
+    public function testDummyAction(): void
+    {
+        // Fails if AN_ANNOYING_ENV is available.
+    }
+
+    public function testOtherDummyAction(): void
+    {
+        // Does not fail.
+    }
+}
+```
+
+### Forbid multiple environment variables
+
+Class level:
+
+```php
+#[ForbidsEnv('AN_ANNOYING_ENV')]
+#[ForbidsEnv('ANOTHER_VERY_ANNOYING_ENV')]
+final class DummyTest extends TestCase
+{
+    public function testDummyAction(): void
+    {
+        // Skipped if AN_ANNOYING_ENV and/or ANOTHER_VERY_ANNOYING_ENV environment variables are available.
+    }
+
+    public function testOtherDummyAction(): void
+    {
+        // Skipped if AN_ANNOYING_ENV and/or ANOTHER_VERY_ANNOYING_ENV environment variables are available.
+    }
+}
+```
+
+Method level:
+
+```php
+final class DummyTest extends TestCase
+{
+    #[ForbidsEnv('AN_ANNOYING_ENV')]
+    #[ForbidsEnv('ANOTHER_VERY_ANNOYING_ENV')]
+    public function testDummyAction(): void
+    {
+        // Skipped if AN_ANNOYING_ENV and/or ANOTHER_VERY_ANNOYING_ENV environment variables are available.
+    }
+
+    public function testOtherDummyAction(): void
+    {
+        // Not skipped.
+    }
+}
+```
+
+</details>

--- a/docs/attributes/requires-env.md
+++ b/docs/attributes/requires-env.md
@@ -1,0 +1,196 @@
+# [`#[RequiresEnv]`](../../src/Attribute/RequiresEnv.php)
+
+_Scope: Class & Method level_
+
+With this attribute, tests or test cases can be marked as to be only executed
+if a certain environment variable exists. The environment variable is checked
+using [`getenv`](https://www.php.net/manual/en/function.getenv.php) and via the
+[`$_ENV`](https://www.php.net/manual/en/reserved.variables.environment.php)
+superglobal.
+
+## Configuration
+
+By default, test cases requiring environment variables are skipped. However,
+this behavior can be configured by using the `handleMissingEnvironmentVariables`
+extension parameter. If set to `fail`, test cases with missing environment
+variables will fail (defaults to `skip`):
+
+```xml
+<extensions>
+    <bootstrap class="EliasHaeussler\PHPUnitAttributes\PHPUnitAttributesExtension">
+        <parameter name="handleMissingEnvironmentVariables" value="fail" />
+    </bootstrap>
+</extensions>
+```
+
+## Example
+
+```php
+final class DummyTest extends TestCase
+{
+    #[RequiresEnv('AN_IMPORTANT_ENV')]
+    public function testDummyAction(): void
+    {
+        // ...
+    }
+}
+```
+
+<details>
+<summary>More examples</summary>
+
+### Require single environment variable
+
+Class level:
+
+```php
+#[RequiresEnv('AN_IMPORTANT_ENV')]
+final class DummyTest extends TestCase
+{
+    public function testDummyAction(): void
+    {
+        // Skipped if AN_IMPORTANT_ENV is missing.
+    }
+
+    public function testOtherDummyAction(): void
+    {
+        // Skipped if AN_IMPORTANT_ENV is missing.
+    }
+}
+```
+
+Method level:
+
+```php
+final class DummyTest extends TestCase
+{
+    #[RequiresEnv('AN_IMPORTANT_ENV')]
+    public function testDummyAction(): void
+    {
+        // Skipped if AN_IMPORTANT_ENV is missing.
+    }
+
+    public function testOtherDummyAction(): void
+    {
+        // Not skipped.
+    }
+}
+```
+
+### Require single environment variable and provide custom message
+
+Class level:
+
+```php
+#[RequiresEnv('AN_IMPORTANT_ENV', 'This test requires an important env var.')]
+final class DummyTest extends TestCase
+{
+    public function testDummyAction(): void
+    {
+        // Skipped if AN_IMPORTANT_ENV is missing, along with custom message.
+    }
+
+    public function testOtherDummyAction(): void
+    {
+        // Skipped if AN_IMPORTANT_ENV is missing, along with custom message.
+    }
+}
+```
+
+Method level:
+
+```php
+final class DummyTest extends TestCase
+{
+    #[RequiresEnv('AN_IMPORTANT_ENV', 'This test requires an important env var.')]
+    public function testDummyAction(): void
+    {
+        // Skipped if AN_IMPORTANT_ENV is missing, along with custom message.
+    }
+
+    public function testOtherDummyAction(): void
+    {
+        // Not skipped.
+    }
+}
+```
+
+### Require single environment variable and define custom outcome behavior
+
+Class level:
+
+```php
+#[RequiresEnv('AN_IMPORTANT_ENV', outcomeBehavior: OutcomeBehavior::Fail)]
+final class DummyTest extends TestCase
+{
+    public function testDummyAction(): void
+    {
+        // Fails if AN_IMPORTANT_ENV is missing.
+    }
+
+    public function testOtherDummyAction(): void
+    {
+        // Fails if AN_IMPORTANT_ENV is missing.
+    }
+}
+```
+
+Method level:
+
+```php
+final class DummyTest extends TestCase
+{
+    #[RequiresEnv('AN_IMPORTANT_ENV', outcomeBehavior: OutcomeBehavior::Fail)]
+    public function testDummyAction(): void
+    {
+        // Fails if AN_IMPORTANT_ENV is missing.
+    }
+
+    public function testOtherDummyAction(): void
+    {
+        // Does not fail.
+    }
+}
+```
+
+### Require multiple environment variables
+
+Class level:
+
+```php
+#[RequiresEnv('AN_IMPORTANT_ENV')]
+#[RequiresEnv('ANOTHER_VERY_IMPORTANT_ENV')]
+final class DummyTest extends TestCase
+{
+    public function testDummyAction(): void
+    {
+        // Skipped if AN_IMPORTANT_ENV and/or ANOTHER_VERY_IMPORTANT_ENV environment variables are missing.
+    }
+
+    public function testOtherDummyAction(): void
+    {
+        // Skipped if AN_IMPORTANT_ENV and/or ANOTHER_VERY_IMPORTANT_ENV environment variables are missing.
+    }
+}
+```
+
+Method level:
+
+```php
+final class DummyTest extends TestCase
+{
+    #[RequiresEnv('AN_IMPORTANT_ENV')]
+    #[RequiresEnv('ANOTHER_VERY_IMPORTANT_ENV')]
+    public function testDummyAction(): void
+    {
+        // Skipped if AN_IMPORTANT_ENV and/or ANOTHER_VERY_IMPORTANT_ENV environment variables are missing.
+    }
+
+    public function testOtherDummyAction(): void
+    {
+        // Not skipped.
+    }
+}
+```
+
+</details>

--- a/src/Attribute/ForbidsEnv.php
+++ b/src/Attribute/ForbidsEnv.php
@@ -27,30 +27,26 @@ use Attribute;
 use EliasHaeussler\PHPUnitAttributes\Enum;
 
 /**
- * ForbisClass.
+ * ForbisEnv.
  *
  * @author Elias Häußler <elias@haeussler.dev>
  * @license GPL-3.0-or-later
  */
 #[Attribute(Attribute::TARGET_METHOD | Attribute::TARGET_CLASS | Attribute::IS_REPEATABLE)]
-final class ForbidsClass
+final class ForbidsEnv
 {
     /**
-     * @param class-string          $className
      * @param non-empty-string|null $message
      */
     public function __construct(
-        private readonly string $className,
+        private readonly string $envVariableName,
         private readonly ?string $message = null,
         private readonly ?Enum\OutcomeBehavior $outcomeBehavior = null,
     ) {}
 
-    /**
-     * @return class-string
-     */
-    public function className(): string
+    public function envVariableName(): string
     {
-        return $this->className;
+        return $this->envVariableName;
     }
 
     /**

--- a/src/Attribute/RequiresEnv.php
+++ b/src/Attribute/RequiresEnv.php
@@ -27,30 +27,26 @@ use Attribute;
 use EliasHaeussler\PHPUnitAttributes\Enum;
 
 /**
- * ForbisClass.
+ * RequiresEnv.
  *
  * @author Elias Häußler <elias@haeussler.dev>
  * @license GPL-3.0-or-later
  */
 #[Attribute(Attribute::TARGET_METHOD | Attribute::TARGET_CLASS | Attribute::IS_REPEATABLE)]
-final class ForbidsClass
+final class RequiresEnv
 {
     /**
-     * @param class-string          $className
      * @param non-empty-string|null $message
      */
     public function __construct(
-        private readonly string $className,
+        private readonly string $envVariableName,
         private readonly ?string $message = null,
         private readonly ?Enum\OutcomeBehavior $outcomeBehavior = null,
     ) {}
 
-    /**
-     * @return class-string
-     */
-    public function className(): string
+    public function envVariableName(): string
     {
-        return $this->className;
+        return $this->envVariableName;
     }
 
     /**

--- a/src/Event/Tracer/ForbidsEnvAttributeTracer.php
+++ b/src/Event/Tracer/ForbidsEnvAttributeTracer.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/phpunit-attributes".
+ *
+ * Copyright (C) 2024-2025 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\PHPUnitAttributes\Event\Tracer;
+
+use EliasHaeussler\PHPUnitAttributes\Attribute;
+use EliasHaeussler\PHPUnitAttributes\Enum;
+use EliasHaeussler\PHPUnitAttributes\Metadata;
+
+/**
+ * ForbidsEnvAttributeTracer.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ *
+ * @extends AbstractAttributeTracer<Attribute\ForbidsEnv>
+ */
+final class ForbidsEnvAttributeTracer extends AbstractAttributeTracer
+{
+    public function __construct(
+        private readonly Metadata\EnvRequirements $envRequirements,
+        Enum\OutcomeBehavior $behaviorOnAvailableEnvironmentVariables,
+    ) {
+        $this->defaultOutcomeBehavior = $behaviorOnAvailableEnvironmentVariables;
+    }
+
+    protected function resolveBehaviorsFromAttributes(array $attributes): array
+    {
+        $notSatisfied = [];
+
+        foreach ($attributes as $attribute) {
+            $message = $this->envRequirements->validateForAttribute($attribute);
+
+            if (null !== $message) {
+                $notSatisfied[$message] = $attribute->outcomeBehavior() ?? $this->defaultOutcomeBehavior;
+            }
+        }
+
+        return $notSatisfied;
+    }
+
+    protected function getAttributeClassName(): string
+    {
+        return Attribute\ForbidsEnv::class;
+    }
+}

--- a/src/Event/Tracer/RequiresEnvAttributeTracer.php
+++ b/src/Event/Tracer/RequiresEnvAttributeTracer.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/phpunit-attributes".
+ *
+ * Copyright (C) 2024-2025 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\PHPUnitAttributes\Event\Tracer;
+
+use EliasHaeussler\PHPUnitAttributes\Attribute;
+use EliasHaeussler\PHPUnitAttributes\Enum;
+use EliasHaeussler\PHPUnitAttributes\Metadata;
+
+/**
+ * RequiresEnvAttributeTracer.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ *
+ * @extends AbstractAttributeTracer<Attribute\RequiresEnv>
+ */
+final class RequiresEnvAttributeTracer extends AbstractAttributeTracer
+{
+    public function __construct(
+        private readonly Metadata\EnvRequirements $envRequirements,
+        Enum\OutcomeBehavior $behaviorOnMissingEnvironmentVariables,
+    ) {
+        $this->defaultOutcomeBehavior = $behaviorOnMissingEnvironmentVariables;
+    }
+
+    protected function resolveBehaviorsFromAttributes(array $attributes): array
+    {
+        $notSatisfied = [];
+
+        foreach ($attributes as $attribute) {
+            $message = $this->envRequirements->validateForAttribute($attribute);
+
+            if (null !== $message) {
+                $notSatisfied[$message] = $attribute->outcomeBehavior() ?? $this->defaultOutcomeBehavior;
+            }
+        }
+
+        return $notSatisfied;
+    }
+
+    protected function getAttributeClassName(): string
+    {
+        return Attribute\RequiresEnv::class;
+    }
+}

--- a/src/Metadata/EnvRequirements.php
+++ b/src/Metadata/EnvRequirements.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/phpunit-attributes".
+ *
+ * Copyright (C) 2024-2025 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\PHPUnitAttributes\Metadata;
+
+use EliasHaeussler\PHPUnitAttributes\Attribute;
+use EliasHaeussler\PHPUnitAttributes\TextUI;
+
+use function getenv;
+
+/**
+ * EnvRequirements.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ */
+final class EnvRequirements
+{
+    /**
+     * @return non-empty-string|null
+     */
+    public function validateForAttribute(Attribute\RequiresEnv|Attribute\ForbidsEnv $attribute): ?string
+    {
+        $envVariableName = $attribute->envVariableName();
+        $message = $attribute->message();
+        $envVariableValue = getenv($envVariableName);
+
+        if (false === $envVariableValue) {
+            $envVariableValue = $_ENV[$envVariableName] ?? null;
+        }
+
+        if (null === $envVariableValue && $attribute instanceof Attribute\RequiresEnv) {
+            return $message ?? TextUI\Messages::forMissingEnvironmentVariable($envVariableName);
+        }
+
+        if (null !== $envVariableValue && $attribute instanceof Attribute\ForbidsEnv) {
+            return $message ?? TextUI\Messages::forAvailableEnvironmentVariable($envVariableName);
+        }
+
+        return null;
+    }
+}

--- a/src/PHPUnitAttributesExtension.php
+++ b/src/PHPUnitAttributesExtension.php
@@ -47,6 +47,7 @@ final class PHPUnitAttributesExtension implements Runner\Extension\Extension
         $requiresClassMigrationResult = $this->registerClassAttributeTracers($facade, $parameters);
         $this->registerConstantAttributeTracers($facade, $parameters);
         $requiresPackageMigrationResult = $this->registerPackageAttributeTracers($facade, $parameters);
+        $this->registerEnvAttributeTracers($facade, $parameters);
 
         $this->triggerDeprecationForMigratedConfigurationParameters(
             $configuration->colors(),
@@ -134,6 +135,27 @@ final class PHPUnitAttributesExtension implements Runner\Extension\Extension
         );
 
         return $migrationResult;
+    }
+
+    private function registerEnvAttributeTracers(
+        Runner\Extension\Facade $facade,
+        Runner\Extension\ParameterCollection $parameters,
+    ): void {
+        // RequiresEnv
+        $facade->registerTracer(
+            new Event\Tracer\RequiresEnvAttributeTracer(
+                new Metadata\EnvRequirements(),
+                $this->resolveOutcomeBehavior('handleMissingEnvironmentVariables', $parameters),
+            ),
+        );
+
+        // ForbidsEnv
+        $facade->registerTracer(
+            new Event\Tracer\ForbidsEnvAttributeTracer(
+                new Metadata\EnvRequirements(),
+                $this->resolveOutcomeBehavior('handleAvailableEnvironmentVariables', $parameters),
+            ),
+        );
     }
 
     /**

--- a/src/TextUI/Messages.php
+++ b/src/TextUI/Messages.php
@@ -105,4 +105,20 @@ final class Messages
     {
         return sprintf('Constant "%s" is forbidden.', $constant);
     }
+
+    /**
+     * @return non-empty-string
+     */
+    public static function forMissingEnvironmentVariable(string $envVariableName): string
+    {
+        return sprintf('Environment variable "%s" is required.', $envVariableName);
+    }
+
+    /**
+     * @return non-empty-string
+     */
+    public static function forAvailableEnvironmentVariable(string $envVariableName): string
+    {
+        return sprintf('Environment variable "%s" is forbidden.', $envVariableName);
+    }
 }

--- a/tests/e2e/forbids-env-attribute/custom-message.phpt
+++ b/tests/e2e/forbids-env-attribute/custom-message.phpt
@@ -1,0 +1,32 @@
+--TEST--
+The #[ForbidsEnv] attribute is applied with custom message
+--FILE--
+<?php
+
+declare(strict_types=1);
+
+$_SERVER['argv'][] = '--do-not-cache-result';
+$_SERVER['argv'][] = '--display-skipped';
+$_SERVER['argv'][] = '--configuration';
+$_SERVER['argv'][] = __DIR__ . '/fixtures/custom-message/phpunit.xml';
+
+require dirname(__DIR__, 3) . '/vendor/autoload.php';
+
+(new \PHPUnit\TextUI\Application())->run($_SERVER['argv']);
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+Runtime: %s
+Configuration: %s
+
+S                                                                   1 / 1 (100%)
+
+Time: %s, Memory: %s
+
+There was 1 skipped test:
+
+1) EliasHaeussler\PHPUnitAttributes\Tests\E2E\ForbidsEnvAttributeWithCustomMessageTest::fakeTest
+You're obviously having some envs...
+
+OK, but some tests were skipped!
+Tests: 1, Assertions: 0, Skipped: 1.

--- a/tests/e2e/forbids-env-attribute/fail-on-unsatisfied-requirement.phpt
+++ b/tests/e2e/forbids-env-attribute/fail-on-unsatisfied-requirement.phpt
@@ -1,0 +1,35 @@
+--TEST--
+The #[ForbidsEnv] attribute causes tests with unsatisified requirement to fail
+--FILE--
+<?php
+
+declare(strict_types=1);
+
+$_SERVER['argv'][] = '--do-not-cache-result';
+$_SERVER['argv'][] = '--configuration';
+$_SERVER['argv'][] = __DIR__ . '/fixtures/fail-on-unsatisfied-requirement/phpunit.xml';
+
+require dirname(__DIR__, 3) . '/vendor/autoload.php';
+
+(new \PHPUnit\TextUI\Application())->run($_SERVER['argv']);
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+Runtime: %s
+Configuration: %s
+
+F.                                                                  2 / 2 (100%)
+
+Time: %s, Memory: %s
+
+There was 1 failure:
+
+1) EliasHaeussler\PHPUnitAttributes\Tests\E2E\ForbidsEnvAttributeFailsOnUnsatisfiedRequirementTest::fakeTest
+Environment variable "FOO_BAZ" is forbidden.
+
+%s
+%s
+%s
+
+FAILURES!
+Tests: 2, Assertions: 2, Failures: 1.

--- a/tests/e2e/forbids-env-attribute/fixtures/custom-message/phpunit.xml
+++ b/tests/e2e/forbids-env-attribute/fixtures/custom-message/phpunit.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="../../../../../vendor/phpunit/phpunit/phpunit.xsd"
+>
+    <php>
+        <env name="FOO_BAZ" value="bar" />
+    </php>
+    <extensions>
+        <bootstrap class="EliasHaeussler\PHPUnitAttributes\PHPUnitAttributesExtension" />
+    </extensions>
+    <testsuites>
+        <testsuite name="default">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/tests/e2e/forbids-env-attribute/fixtures/custom-message/tests/ForbidsEnvAttributeWithCustomMessageTest.php
+++ b/tests/e2e/forbids-env-attribute/fixtures/custom-message/tests/ForbidsEnvAttributeWithCustomMessageTest.php
@@ -21,48 +21,23 @@ declare(strict_types=1);
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
-namespace EliasHaeussler\PHPUnitAttributes\Attribute;
+namespace EliasHaeussler\PHPUnitAttributes\Tests\E2E;
 
-use Attribute;
-use EliasHaeussler\PHPUnitAttributes\Enum;
+use EliasHaeussler\PHPUnitAttributes as Src;
+use PHPUnit\Framework;
 
 /**
- * ForbisClass.
+ * ForbidsEnvAttributeWithCustomMessageTest.
  *
  * @author Elias Häußler <elias@haeussler.dev>
  * @license GPL-3.0-or-later
  */
-#[Attribute(Attribute::TARGET_METHOD | Attribute::TARGET_CLASS | Attribute::IS_REPEATABLE)]
-final class ForbidsClass
+final class ForbidsEnvAttributeWithCustomMessageTest extends Framework\TestCase
 {
-    /**
-     * @param class-string          $className
-     * @param non-empty-string|null $message
-     */
-    public function __construct(
-        private readonly string $className,
-        private readonly ?string $message = null,
-        private readonly ?Enum\OutcomeBehavior $outcomeBehavior = null,
-    ) {}
-
-    /**
-     * @return class-string
-     */
-    public function className(): string
+    #[Framework\Attributes\Test]
+    #[Src\Attribute\ForbidsEnv('FOO_BAZ', 'You\'re obviously having some envs...')]
+    public function fakeTest(): void
     {
-        return $this->className;
-    }
-
-    /**
-     * @return non-empty-string|null
-     */
-    public function message(): ?string
-    {
-        return $this->message;
-    }
-
-    public function outcomeBehavior(): ?Enum\OutcomeBehavior
-    {
-        return $this->outcomeBehavior;
+        self::assertTrue(true);
     }
 }

--- a/tests/e2e/forbids-env-attribute/fixtures/fail-on-unsatisfied-requirement/phpunit.xml
+++ b/tests/e2e/forbids-env-attribute/fixtures/fail-on-unsatisfied-requirement/phpunit.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="../../../../../vendor/phpunit/phpunit/phpunit.xsd"
+>
+    <php>
+        <env name="FOO_BAZ" value="bar" />
+    </php>
+    <extensions>
+        <bootstrap class="EliasHaeussler\PHPUnitAttributes\PHPUnitAttributesExtension">
+            <parameter name="handleAvailableEnvironmentVariables" value="fail" />
+        </bootstrap>
+    </extensions>
+    <testsuites>
+        <testsuite name="default">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/tests/e2e/forbids-env-attribute/fixtures/fail-on-unsatisfied-requirement/tests/ForbidsEnvAttributeFailsOnUnsatisfiedRequirementTest.php
+++ b/tests/e2e/forbids-env-attribute/fixtures/fail-on-unsatisfied-requirement/tests/ForbidsEnvAttributeFailsOnUnsatisfiedRequirementTest.php
@@ -21,48 +21,29 @@ declare(strict_types=1);
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
-namespace EliasHaeussler\PHPUnitAttributes\Attribute;
+namespace EliasHaeussler\PHPUnitAttributes\Tests\E2E;
 
-use Attribute;
-use EliasHaeussler\PHPUnitAttributes\Enum;
+use EliasHaeussler\PHPUnitAttributes as Src;
+use PHPUnit\Framework;
 
 /**
- * ForbisClass.
+ * ForbidsEnvAttributeFailsOnUnsatisfiedRequirementTest.
  *
  * @author Elias Häußler <elias@haeussler.dev>
  * @license GPL-3.0-or-later
  */
-#[Attribute(Attribute::TARGET_METHOD | Attribute::TARGET_CLASS | Attribute::IS_REPEATABLE)]
-final class ForbidsClass
+final class ForbidsEnvAttributeFailsOnUnsatisfiedRequirementTest extends Framework\TestCase
 {
-    /**
-     * @param class-string          $className
-     * @param non-empty-string|null $message
-     */
-    public function __construct(
-        private readonly string $className,
-        private readonly ?string $message = null,
-        private readonly ?Enum\OutcomeBehavior $outcomeBehavior = null,
-    ) {}
-
-    /**
-     * @return class-string
-     */
-    public function className(): string
+    #[Framework\Attributes\Test]
+    #[Src\Attribute\ForbidsEnv('FOO_BAZ')]
+    public function fakeTest(): void
     {
-        return $this->className;
+        self::assertTrue(true);
     }
 
-    /**
-     * @return non-empty-string|null
-     */
-    public function message(): ?string
+    #[Framework\Attributes\Test]
+    public function anotherFakeTest(): void
     {
-        return $this->message;
-    }
-
-    public function outcomeBehavior(): ?Enum\OutcomeBehavior
-    {
-        return $this->outcomeBehavior;
+        self::assertTrue(true);
     }
 }

--- a/tests/e2e/forbids-env-attribute/fixtures/skip-on-invalid-configuration-value/phpunit.xml
+++ b/tests/e2e/forbids-env-attribute/fixtures/skip-on-invalid-configuration-value/phpunit.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="../../../../../vendor/phpunit/phpunit/phpunit.xsd"
+>
+    <php>
+        <env name="FOO_BAZ" value="bar" />
+    </php>
+    <extensions>
+        <bootstrap class="EliasHaeussler\PHPUnitAttributes\PHPUnitAttributesExtension">
+            <!-- "foo" is invalid here by purpose, test verifies that it's normalized to ”skip" -->
+            <parameter name="handleAvailableEnvironmentVariables" value="foo" />
+        </bootstrap>
+    </extensions>
+    <testsuites>
+        <testsuite name="default">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/tests/e2e/forbids-env-attribute/fixtures/skip-on-invalid-configuration-value/tests/ForbidsEnvAttributeSkipsOnInvalidConfigurationValueTest.php
+++ b/tests/e2e/forbids-env-attribute/fixtures/skip-on-invalid-configuration-value/tests/ForbidsEnvAttributeSkipsOnInvalidConfigurationValueTest.php
@@ -21,48 +21,29 @@ declare(strict_types=1);
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
-namespace EliasHaeussler\PHPUnitAttributes\Attribute;
+namespace EliasHaeussler\PHPUnitAttributes\Tests\E2E;
 
-use Attribute;
-use EliasHaeussler\PHPUnitAttributes\Enum;
+use EliasHaeussler\PHPUnitAttributes as Src;
+use PHPUnit\Framework;
 
 /**
- * ForbisClass.
+ * ForbidsEnvAttributeSkipsOnInvalidConfigurationValueTest.
  *
  * @author Elias Häußler <elias@haeussler.dev>
  * @license GPL-3.0-or-later
  */
-#[Attribute(Attribute::TARGET_METHOD | Attribute::TARGET_CLASS | Attribute::IS_REPEATABLE)]
-final class ForbidsClass
+final class ForbidsEnvAttributeSkipsOnInvalidConfigurationValueTest extends Framework\TestCase
 {
-    /**
-     * @param class-string          $className
-     * @param non-empty-string|null $message
-     */
-    public function __construct(
-        private readonly string $className,
-        private readonly ?string $message = null,
-        private readonly ?Enum\OutcomeBehavior $outcomeBehavior = null,
-    ) {}
-
-    /**
-     * @return class-string
-     */
-    public function className(): string
+    #[Framework\Attributes\Test]
+    #[Src\Attribute\ForbidsEnv('FOO_BAZ')]
+    public function fakeTest(): void
     {
-        return $this->className;
+        self::assertTrue(true);
     }
 
-    /**
-     * @return non-empty-string|null
-     */
-    public function message(): ?string
+    #[Framework\Attributes\Test]
+    public function anotherFakeTest(): void
     {
-        return $this->message;
-    }
-
-    public function outcomeBehavior(): ?Enum\OutcomeBehavior
-    {
-        return $this->outcomeBehavior;
+        self::assertTrue(true);
     }
 }

--- a/tests/e2e/forbids-env-attribute/fixtures/skip-on-unsatisfied-requirement/phpunit.xml
+++ b/tests/e2e/forbids-env-attribute/fixtures/skip-on-unsatisfied-requirement/phpunit.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="../../../../../vendor/phpunit/phpunit/phpunit.xsd"
+>
+    <php>
+        <env name="FOO_BAZ" value="bar" />
+    </php>
+    <extensions>
+        <bootstrap class="EliasHaeussler\PHPUnitAttributes\PHPUnitAttributesExtension">
+            <parameter name="handleAvailableEnvironmentVariables" value="skip" />
+        </bootstrap>
+    </extensions>
+    <testsuites>
+        <testsuite name="default">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/tests/e2e/forbids-env-attribute/fixtures/skip-on-unsatisfied-requirement/tests/ForbidsEnvAttributeSkipsOnUnsatisfiedRequirementTest.php
+++ b/tests/e2e/forbids-env-attribute/fixtures/skip-on-unsatisfied-requirement/tests/ForbidsEnvAttributeSkipsOnUnsatisfiedRequirementTest.php
@@ -21,48 +21,29 @@ declare(strict_types=1);
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
-namespace EliasHaeussler\PHPUnitAttributes\Attribute;
+namespace EliasHaeussler\PHPUnitAttributes\Tests\E2E;
 
-use Attribute;
-use EliasHaeussler\PHPUnitAttributes\Enum;
+use EliasHaeussler\PHPUnitAttributes as Src;
+use PHPUnit\Framework;
 
 /**
- * ForbisClass.
+ * ForbidsEnvAttributeSkipsOnUnsatisfiedRequirementTest.
  *
  * @author Elias Häußler <elias@haeussler.dev>
  * @license GPL-3.0-or-later
  */
-#[Attribute(Attribute::TARGET_METHOD | Attribute::TARGET_CLASS | Attribute::IS_REPEATABLE)]
-final class ForbidsClass
+final class ForbidsEnvAttributeSkipsOnUnsatisfiedRequirementTest extends Framework\TestCase
 {
-    /**
-     * @param class-string          $className
-     * @param non-empty-string|null $message
-     */
-    public function __construct(
-        private readonly string $className,
-        private readonly ?string $message = null,
-        private readonly ?Enum\OutcomeBehavior $outcomeBehavior = null,
-    ) {}
-
-    /**
-     * @return class-string
-     */
-    public function className(): string
+    #[Framework\Attributes\Test]
+    #[Src\Attribute\ForbidsEnv('FOO_BAZ')]
+    public function fakeTest(): void
     {
-        return $this->className;
+        self::assertTrue(true);
     }
 
-    /**
-     * @return non-empty-string|null
-     */
-    public function message(): ?string
+    #[Framework\Attributes\Test]
+    public function anotherFakeTest(): void
     {
-        return $this->message;
-    }
-
-    public function outcomeBehavior(): ?Enum\OutcomeBehavior
-    {
-        return $this->outcomeBehavior;
+        self::assertTrue(true);
     }
 }

--- a/tests/e2e/forbids-env-attribute/skip-on-invalid-configuration-value.phpt
+++ b/tests/e2e/forbids-env-attribute/skip-on-invalid-configuration-value.phpt
@@ -1,0 +1,32 @@
+--TEST--
+Invalid configuration options are normalized to tests with unsatisfied requirements being skipped
+--FILE--
+<?php
+
+declare(strict_types=1);
+
+$_SERVER['argv'][] = '--do-not-cache-result';
+$_SERVER['argv'][] = '--display-skipped';
+$_SERVER['argv'][] = '--configuration';
+$_SERVER['argv'][] = __DIR__ . '/fixtures/skip-on-invalid-configuration-value/phpunit.xml';
+
+require dirname(__DIR__, 3) . '/vendor/autoload.php';
+
+(new \PHPUnit\TextUI\Application())->run($_SERVER['argv']);
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+Runtime: %s
+Configuration: %s
+
+S.                                                                  2 / 2 (100%)
+
+Time: %s, Memory: %s
+
+There was 1 skipped test:
+
+1) EliasHaeussler\PHPUnitAttributes\Tests\E2E\ForbidsEnvAttributeSkipsOnInvalidConfigurationValueTest::fakeTest
+Environment variable "FOO_BAZ" is forbidden.
+
+OK, but some tests were skipped!
+Tests: 2, Assertions: 1, Skipped: 1.

--- a/tests/e2e/forbids-env-attribute/skip-on-unsatisfied-requirement.phpt
+++ b/tests/e2e/forbids-env-attribute/skip-on-unsatisfied-requirement.phpt
@@ -1,0 +1,32 @@
+--TEST--
+The #[ForbidsEnv] attribute causes tests with unsatisified requirement to be skipped
+--FILE--
+<?php
+
+declare(strict_types=1);
+
+$_SERVER['argv'][] = '--do-not-cache-result';
+$_SERVER['argv'][] = '--display-skipped';
+$_SERVER['argv'][] = '--configuration';
+$_SERVER['argv'][] = __DIR__ . '/fixtures/skip-on-unsatisfied-requirement/phpunit.xml';
+
+require dirname(__DIR__, 3) . '/vendor/autoload.php';
+
+(new \PHPUnit\TextUI\Application())->run($_SERVER['argv']);
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+Runtime: %s
+Configuration: %s
+
+S.                                                                  2 / 2 (100%)
+
+Time: %s, Memory: %s
+
+There was 1 skipped test:
+
+1) EliasHaeussler\PHPUnitAttributes\Tests\E2E\ForbidsEnvAttributeSkipsOnUnsatisfiedRequirementTest::fakeTest
+Environment variable "FOO_BAZ" is forbidden.
+
+OK, but some tests were skipped!
+Tests: 2, Assertions: 1, Skipped: 1.

--- a/tests/e2e/requires-env-attribute/custom-message.phpt
+++ b/tests/e2e/requires-env-attribute/custom-message.phpt
@@ -1,0 +1,32 @@
+--TEST--
+The #[RequiresEnv] attribute is applied with custom message
+--FILE--
+<?php
+
+declare(strict_types=1);
+
+$_SERVER['argv'][] = '--do-not-cache-result';
+$_SERVER['argv'][] = '--display-skipped';
+$_SERVER['argv'][] = '--configuration';
+$_SERVER['argv'][] = __DIR__ . '/fixtures/custom-message/phpunit.xml';
+
+require dirname(__DIR__, 3) . '/vendor/autoload.php';
+
+(new \PHPUnit\TextUI\Application())->run($_SERVER['argv']);
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+Runtime: %s
+Configuration: %s
+
+S                                                                   1 / 1 (100%)
+
+Time: %s, Memory: %s
+
+There was 1 skipped test:
+
+1) EliasHaeussler\PHPUnitAttributes\Tests\E2E\RequiresEnvAttributeWithCustomMessageTest::fakeTest
+You're obviously missing some envs...
+
+OK, but some tests were skipped!
+Tests: 1, Assertions: 0, Skipped: 1.

--- a/tests/e2e/requires-env-attribute/fail-on-unsatisfied-requirement.phpt
+++ b/tests/e2e/requires-env-attribute/fail-on-unsatisfied-requirement.phpt
@@ -1,0 +1,35 @@
+--TEST--
+The #[RequiresEnv] attribute causes tests with unsatisified requirement to fail
+--FILE--
+<?php
+
+declare(strict_types=1);
+
+$_SERVER['argv'][] = '--do-not-cache-result';
+$_SERVER['argv'][] = '--configuration';
+$_SERVER['argv'][] = __DIR__ . '/fixtures/fail-on-unsatisfied-requirement/phpunit.xml';
+
+require dirname(__DIR__, 3) . '/vendor/autoload.php';
+
+(new \PHPUnit\TextUI\Application())->run($_SERVER['argv']);
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+Runtime: %s
+Configuration: %s
+
+F.                                                                  2 / 2 (100%)
+
+Time: %s, Memory: %s
+
+There was 1 failure:
+
+1) EliasHaeussler\PHPUnitAttributes\Tests\E2E\RequiresEnvAttributeFailsOnUnsatisfiedRequirementTest::fakeTest
+Environment variable "FOO_BAZ" is required.
+
+%s
+%s
+%s
+
+FAILURES!
+Tests: 2, Assertions: 2, Failures: 1.

--- a/tests/e2e/requires-env-attribute/fixtures/custom-message/phpunit.xml
+++ b/tests/e2e/requires-env-attribute/fixtures/custom-message/phpunit.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="../../../../../vendor/phpunit/phpunit/phpunit.xsd"
+>
+    <extensions>
+        <bootstrap class="EliasHaeussler\PHPUnitAttributes\PHPUnitAttributesExtension" />
+    </extensions>
+    <testsuites>
+        <testsuite name="default">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/tests/e2e/requires-env-attribute/fixtures/custom-message/tests/RequiresEnvAttributeWithCustomMessageTest.php
+++ b/tests/e2e/requires-env-attribute/fixtures/custom-message/tests/RequiresEnvAttributeWithCustomMessageTest.php
@@ -21,48 +21,23 @@ declare(strict_types=1);
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
-namespace EliasHaeussler\PHPUnitAttributes\Attribute;
+namespace EliasHaeussler\PHPUnitAttributes\Tests\E2E;
 
-use Attribute;
-use EliasHaeussler\PHPUnitAttributes\Enum;
+use EliasHaeussler\PHPUnitAttributes as Src;
+use PHPUnit\Framework;
 
 /**
- * ForbisClass.
+ * RequiresEnvAttributeWithCustomMessageTest.
  *
  * @author Elias Häußler <elias@haeussler.dev>
  * @license GPL-3.0-or-later
  */
-#[Attribute(Attribute::TARGET_METHOD | Attribute::TARGET_CLASS | Attribute::IS_REPEATABLE)]
-final class ForbidsClass
+final class RequiresEnvAttributeWithCustomMessageTest extends Framework\TestCase
 {
-    /**
-     * @param class-string          $className
-     * @param non-empty-string|null $message
-     */
-    public function __construct(
-        private readonly string $className,
-        private readonly ?string $message = null,
-        private readonly ?Enum\OutcomeBehavior $outcomeBehavior = null,
-    ) {}
-
-    /**
-     * @return class-string
-     */
-    public function className(): string
+    #[Framework\Attributes\Test]
+    #[Src\Attribute\RequiresEnv('FOO_BAZ', 'You\'re obviously missing some envs...')]
+    public function fakeTest(): void
     {
-        return $this->className;
-    }
-
-    /**
-     * @return non-empty-string|null
-     */
-    public function message(): ?string
-    {
-        return $this->message;
-    }
-
-    public function outcomeBehavior(): ?Enum\OutcomeBehavior
-    {
-        return $this->outcomeBehavior;
+        self::assertTrue(true);
     }
 }

--- a/tests/e2e/requires-env-attribute/fixtures/fail-on-unsatisfied-requirement/phpunit.xml
+++ b/tests/e2e/requires-env-attribute/fixtures/fail-on-unsatisfied-requirement/phpunit.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="../../../../../vendor/phpunit/phpunit/phpunit.xsd"
+>
+    <extensions>
+        <bootstrap class="EliasHaeussler\PHPUnitAttributes\PHPUnitAttributesExtension">
+            <parameter name="handleMissingEnvironmentVariables" value="fail" />
+        </bootstrap>
+    </extensions>
+    <testsuites>
+        <testsuite name="default">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/tests/e2e/requires-env-attribute/fixtures/fail-on-unsatisfied-requirement/tests/RequiresEnvAttributeFailsOnUnsatisfiedRequirementTest.php
+++ b/tests/e2e/requires-env-attribute/fixtures/fail-on-unsatisfied-requirement/tests/RequiresEnvAttributeFailsOnUnsatisfiedRequirementTest.php
@@ -21,48 +21,29 @@ declare(strict_types=1);
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
-namespace EliasHaeussler\PHPUnitAttributes\Attribute;
+namespace EliasHaeussler\PHPUnitAttributes\Tests\E2E;
 
-use Attribute;
-use EliasHaeussler\PHPUnitAttributes\Enum;
+use EliasHaeussler\PHPUnitAttributes as Src;
+use PHPUnit\Framework;
 
 /**
- * ForbisClass.
+ * RequiresEnvAttributeFailsOnUnsatisfiedRequirementTest.
  *
  * @author Elias Häußler <elias@haeussler.dev>
  * @license GPL-3.0-or-later
  */
-#[Attribute(Attribute::TARGET_METHOD | Attribute::TARGET_CLASS | Attribute::IS_REPEATABLE)]
-final class ForbidsClass
+final class RequiresEnvAttributeFailsOnUnsatisfiedRequirementTest extends Framework\TestCase
 {
-    /**
-     * @param class-string          $className
-     * @param non-empty-string|null $message
-     */
-    public function __construct(
-        private readonly string $className,
-        private readonly ?string $message = null,
-        private readonly ?Enum\OutcomeBehavior $outcomeBehavior = null,
-    ) {}
-
-    /**
-     * @return class-string
-     */
-    public function className(): string
+    #[Framework\Attributes\Test]
+    #[Src\Attribute\RequiresEnv('FOO_BAZ')]
+    public function fakeTest(): void
     {
-        return $this->className;
+        self::assertTrue(true);
     }
 
-    /**
-     * @return non-empty-string|null
-     */
-    public function message(): ?string
+    #[Framework\Attributes\Test]
+    public function anotherFakeTest(): void
     {
-        return $this->message;
-    }
-
-    public function outcomeBehavior(): ?Enum\OutcomeBehavior
-    {
-        return $this->outcomeBehavior;
+        self::assertTrue(true);
     }
 }

--- a/tests/e2e/requires-env-attribute/fixtures/skip-on-invalid-configuration-value/phpunit.xml
+++ b/tests/e2e/requires-env-attribute/fixtures/skip-on-invalid-configuration-value/phpunit.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="../../../../../vendor/phpunit/phpunit/phpunit.xsd"
+>
+    <extensions>
+        <bootstrap class="EliasHaeussler\PHPUnitAttributes\PHPUnitAttributesExtension">
+            <!-- "foo" is invalid here by purpose, test verifies that it's normalized to ”skip" -->
+            <parameter name="handleMissingEnvironmentVariables" value="foo" />
+        </bootstrap>
+    </extensions>
+    <testsuites>
+        <testsuite name="default">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/tests/e2e/requires-env-attribute/fixtures/skip-on-invalid-configuration-value/tests/RequiresEnvAttributeSkipsOnInvalidConfigurationValueTest.php
+++ b/tests/e2e/requires-env-attribute/fixtures/skip-on-invalid-configuration-value/tests/RequiresEnvAttributeSkipsOnInvalidConfigurationValueTest.php
@@ -21,48 +21,29 @@ declare(strict_types=1);
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
-namespace EliasHaeussler\PHPUnitAttributes\Attribute;
+namespace EliasHaeussler\PHPUnitAttributes\Tests\E2E;
 
-use Attribute;
-use EliasHaeussler\PHPUnitAttributes\Enum;
+use EliasHaeussler\PHPUnitAttributes as Src;
+use PHPUnit\Framework;
 
 /**
- * ForbisClass.
+ * RequiresEnvAttributeSkipsOnInvalidConfigurationValueTest.
  *
  * @author Elias Häußler <elias@haeussler.dev>
  * @license GPL-3.0-or-later
  */
-#[Attribute(Attribute::TARGET_METHOD | Attribute::TARGET_CLASS | Attribute::IS_REPEATABLE)]
-final class ForbidsClass
+final class RequiresEnvAttributeSkipsOnInvalidConfigurationValueTest extends Framework\TestCase
 {
-    /**
-     * @param class-string          $className
-     * @param non-empty-string|null $message
-     */
-    public function __construct(
-        private readonly string $className,
-        private readonly ?string $message = null,
-        private readonly ?Enum\OutcomeBehavior $outcomeBehavior = null,
-    ) {}
-
-    /**
-     * @return class-string
-     */
-    public function className(): string
+    #[Framework\Attributes\Test]
+    #[Src\Attribute\RequiresEnv('FOO_BAZ')]
+    public function fakeTest(): void
     {
-        return $this->className;
+        self::assertTrue(true);
     }
 
-    /**
-     * @return non-empty-string|null
-     */
-    public function message(): ?string
+    #[Framework\Attributes\Test]
+    public function anotherFakeTest(): void
     {
-        return $this->message;
-    }
-
-    public function outcomeBehavior(): ?Enum\OutcomeBehavior
-    {
-        return $this->outcomeBehavior;
+        self::assertTrue(true);
     }
 }

--- a/tests/e2e/requires-env-attribute/fixtures/skip-on-unsatisfied-requirement/phpunit.xml
+++ b/tests/e2e/requires-env-attribute/fixtures/skip-on-unsatisfied-requirement/phpunit.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="../../../../../vendor/phpunit/phpunit/phpunit.xsd"
+>
+    <extensions>
+        <bootstrap class="EliasHaeussler\PHPUnitAttributes\PHPUnitAttributesExtension">
+            <parameter name="handleMissingEnvironmentVariables" value="skip" />
+        </bootstrap>
+    </extensions>
+    <testsuites>
+        <testsuite name="default">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/tests/e2e/requires-env-attribute/fixtures/skip-on-unsatisfied-requirement/tests/RequiresEnvAttributeSkipsOnUnsatisfiedRequirementTest.php
+++ b/tests/e2e/requires-env-attribute/fixtures/skip-on-unsatisfied-requirement/tests/RequiresEnvAttributeSkipsOnUnsatisfiedRequirementTest.php
@@ -21,48 +21,29 @@ declare(strict_types=1);
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
-namespace EliasHaeussler\PHPUnitAttributes\Attribute;
+namespace EliasHaeussler\PHPUnitAttributes\Tests\E2E;
 
-use Attribute;
-use EliasHaeussler\PHPUnitAttributes\Enum;
+use EliasHaeussler\PHPUnitAttributes as Src;
+use PHPUnit\Framework;
 
 /**
- * ForbisClass.
+ * RequiresEnvAttributeSkipsOnUnsatisfiedRequirementTest.
  *
  * @author Elias Häußler <elias@haeussler.dev>
  * @license GPL-3.0-or-later
  */
-#[Attribute(Attribute::TARGET_METHOD | Attribute::TARGET_CLASS | Attribute::IS_REPEATABLE)]
-final class ForbidsClass
+final class RequiresEnvAttributeSkipsOnUnsatisfiedRequirementTest extends Framework\TestCase
 {
-    /**
-     * @param class-string          $className
-     * @param non-empty-string|null $message
-     */
-    public function __construct(
-        private readonly string $className,
-        private readonly ?string $message = null,
-        private readonly ?Enum\OutcomeBehavior $outcomeBehavior = null,
-    ) {}
-
-    /**
-     * @return class-string
-     */
-    public function className(): string
+    #[Framework\Attributes\Test]
+    #[Src\Attribute\RequiresEnv('FOO_BAZ')]
+    public function fakeTest(): void
     {
-        return $this->className;
+        self::assertTrue(true);
     }
 
-    /**
-     * @return non-empty-string|null
-     */
-    public function message(): ?string
+    #[Framework\Attributes\Test]
+    public function anotherFakeTest(): void
     {
-        return $this->message;
-    }
-
-    public function outcomeBehavior(): ?Enum\OutcomeBehavior
-    {
-        return $this->outcomeBehavior;
+        self::assertTrue(true);
     }
 }

--- a/tests/e2e/requires-env-attribute/skip-on-invalid-configuration-value.phpt
+++ b/tests/e2e/requires-env-attribute/skip-on-invalid-configuration-value.phpt
@@ -1,0 +1,32 @@
+--TEST--
+Invalid configuration options are normalized to tests with unsatisfied requirements being skipped
+--FILE--
+<?php
+
+declare(strict_types=1);
+
+$_SERVER['argv'][] = '--do-not-cache-result';
+$_SERVER['argv'][] = '--display-skipped';
+$_SERVER['argv'][] = '--configuration';
+$_SERVER['argv'][] = __DIR__ . '/fixtures/skip-on-invalid-configuration-value/phpunit.xml';
+
+require dirname(__DIR__, 3) . '/vendor/autoload.php';
+
+(new \PHPUnit\TextUI\Application())->run($_SERVER['argv']);
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+Runtime: %s
+Configuration: %s
+
+S.                                                                  2 / 2 (100%)
+
+Time: %s, Memory: %s
+
+There was 1 skipped test:
+
+1) EliasHaeussler\PHPUnitAttributes\Tests\E2E\RequiresEnvAttributeSkipsOnInvalidConfigurationValueTest::fakeTest
+Environment variable "FOO_BAZ" is required.
+
+OK, but some tests were skipped!
+Tests: 2, Assertions: 1, Skipped: 1.

--- a/tests/e2e/requires-env-attribute/skip-on-unsatisfied-requirement.phpt
+++ b/tests/e2e/requires-env-attribute/skip-on-unsatisfied-requirement.phpt
@@ -1,0 +1,32 @@
+--TEST--
+The #[RequiresEnv] attribute causes tests with unsatisified requirement to be skipped
+--FILE--
+<?php
+
+declare(strict_types=1);
+
+$_SERVER['argv'][] = '--do-not-cache-result';
+$_SERVER['argv'][] = '--display-skipped';
+$_SERVER['argv'][] = '--configuration';
+$_SERVER['argv'][] = __DIR__ . '/fixtures/skip-on-unsatisfied-requirement/phpunit.xml';
+
+require dirname(__DIR__, 3) . '/vendor/autoload.php';
+
+(new \PHPUnit\TextUI\Application())->run($_SERVER['argv']);
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+Runtime: %s
+Configuration: %s
+
+S.                                                                  2 / 2 (100%)
+
+Time: %s, Memory: %s
+
+There was 1 skipped test:
+
+1) EliasHaeussler\PHPUnitAttributes\Tests\E2E\RequiresEnvAttributeSkipsOnUnsatisfiedRequirementTest::fakeTest
+Environment variable "FOO_BAZ" is required.
+
+OK, but some tests were skipped!
+Tests: 2, Assertions: 1, Skipped: 1.

--- a/tests/unit/Metadata/EnvRequirementsTest.php
+++ b/tests/unit/Metadata/EnvRequirementsTest.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/phpunit-attributes".
+ *
+ * Copyright (C) 2024-2025 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\PHPUnitAttributes\Tests\Metadata;
+
+use EliasHaeussler\PHPUnitAttributes as Src;
+use Generator;
+use PHPUnit\Framework;
+
+use function putenv;
+
+/**
+ * EnvRequirementsTest.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ */
+#[Framework\Attributes\CoversClass(Src\Metadata\EnvRequirements::class)]
+final class EnvRequirementsTest extends Framework\TestCase
+{
+    private Src\Metadata\EnvRequirements $subject;
+
+    public function setUp(): void
+    {
+        $this->subject = new Src\Metadata\EnvRequirements();
+    }
+
+    /**
+     * @param non-empty-string|null $message
+     */
+    #[Framework\Attributes\Test]
+    #[Framework\Attributes\DataProvider('validateForAttributeReturnsMessageIfEnvironmentVariableDoesNotExistDataProvider')]
+    public function validateForAttributeReturnsMessageIfEnvironmentVariableDoesNotExist(?string $message, string $expected): void
+    {
+        $attribute = new Src\Attribute\RequiresEnv('FOO_BAZ', $message);
+
+        self::assertSame($expected, $this->subject->validateForAttribute($attribute));
+    }
+
+    /**
+     * @param non-empty-string|null $message
+     */
+    #[Framework\Attributes\Test]
+    #[Framework\Attributes\DataProvider('validateForAttributeReturnsMessageIfEnvironmentVariableExistsDataProvider')]
+    public function validateForAttributeReturnsMessageIfEnvironmentVariableExists(?string $message, string $expected): void
+    {
+        $attribute = new Src\Attribute\ForbidsEnv('FOO_BAZ', $message);
+
+        putenv('FOO_BAZ=bar');
+
+        self::assertSame($expected, $this->subject->validateForAttribute($attribute));
+
+        putenv('FOO_BAZ');
+    }
+
+    #[Framework\Attributes\Test]
+    public function validateForAttributeReturnsNullIfEnvironmentVariableExists(): void
+    {
+        $attribute = new Src\Attribute\RequiresEnv('FOO_BAZ');
+
+        putenv('FOO_BAZ=bar');
+
+        self::assertNull($this->subject->validateForAttribute($attribute));
+
+        putenv('FOO_BAZ');
+    }
+
+    #[Framework\Attributes\Test]
+    public function validateForAttributeReturnsNullIfEnvironmentVariableDoesNotExist(): void
+    {
+        $attribute = new Src\Attribute\ForbidsEnv('FOO_BAZ');
+
+        self::assertNull($this->subject->validateForAttribute($attribute));
+    }
+
+    /**
+     * @return Generator<string, array{non-empty-string|null, non-empty-string}>
+     */
+    public static function validateForAttributeReturnsMessageIfEnvironmentVariableDoesNotExistDataProvider(): Generator
+    {
+        yield 'no message' => [null, Src\TextUI\Messages::forMissingEnvironmentVariable('FOO_BAZ')];
+        yield 'custom message' => ['FOO_BAZ is missing, sorry!', 'FOO_BAZ is missing, sorry!'];
+    }
+
+    /**
+     * @return Generator<string, array{non-empty-string|null, non-empty-string}>
+     */
+    public static function validateForAttributeReturnsMessageIfEnvironmentVariableExistsDataProvider(): Generator
+    {
+        yield 'no message' => [null, Src\TextUI\Messages::forAvailableEnvironmentVariable('FOO_BAZ')];
+        yield 'custom message' => ['Env is available, sorry!', 'Env is available, sorry!'];
+    }
+}

--- a/tests/unit/TextUI/MessagesTest.php
+++ b/tests/unit/TextUI/MessagesTest.php
@@ -102,4 +102,22 @@ final class MessagesTest extends Framework\TestCase
             Src\TextUI\Messages::forDefinedConstant('FOO_BAZ'),
         );
     }
+
+    #[Framework\Attributes\Test]
+    public function forMissingEnvironmentVariableReturnsMessageForGivenEnvironmentVariable(): void
+    {
+        self::assertSame(
+            'Environment variable "FOO_BAZ" is required.',
+            Src\TextUI\Messages::forMissingEnvironmentVariable('FOO_BAZ'),
+        );
+    }
+
+    #[Framework\Attributes\Test]
+    public function forAvailableEnvironmentVariableReturnsMessageForGivenEnvironmentVariable(): void
+    {
+        self::assertSame(
+            'Environment variable "FOO_BAZ" is forbidden.',
+            Src\TextUI\Messages::forAvailableEnvironmentVariable('FOO_BAZ'),
+        );
+    }
 }


### PR DESCRIPTION
This pull request introduces new attributes for handling environment variables in PHPUnit tests and updates existing documentation and code to reflect these changes. The key changes include adding new attributes `ForbidsEnv` and `RequiresEnv`, updating the documentation to include these new attributes, and making necessary corrections in the existing documentation.

### New Attributes for Environment Variables:
* [`src/Attribute/ForbidsEnv.php`](diffhunk://#diff-08502aefc4d6757a64262975871c38e620427c7a9efac34c2d8149a804d59ce8R1-R64): Added the `ForbidsEnv` attribute to mark tests that should be skipped or failed if a certain environment variable exists.
* [`src/Attribute/RequiresEnv.php`](diffhunk://#diff-4f9eca4a578394f70b4218d572d8dfc65950714c238c880c0220ea8351fd85a4R1-R64): Added the `RequiresEnv` attribute to mark tests that should be skipped or failed if a certain environment variable is missing.

### Documentation Updates:
* [`docs/attributes/forbids-env.md`](diffhunk://#diff-3fc7862b770395daa7b47267d558af48c9700a6c39ffd51b1d939c9b95aefadfR1-R196): Added documentation for the new `ForbidsEnv` attribute, including configuration and examples.
* [`docs/attributes/requires-env.md`](diffhunk://#diff-34bdc3f7164dcec78bd852facc40307dc54991548a61e1a3cd699f1e85fb9ab2R1-R196): Added documentation for the new `RequiresEnv` attribute, including configuration and examples.
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L80-R85): Updated the README to include links to the new `ForbidsEnv` and `RequiresEnv` attributes.

### Corrections and Improvements:
* [`docs/attributes/forbids-class.md`](diffhunk://#diff-81f4329321748de8929798f32cd0e3a446993ff4ff4cc5ecb8cdc2a1786e0b3fL10-R10): Corrected the wording to accurately reflect the behavior of the `ForbidsClass` attribute. [[1]](diffhunk://#diff-81f4329321748de8929798f32cd0e3a446993ff4ff4cc5ecb8cdc2a1786e0b3fL10-R10) [[2]](diffhunk://#diff-81f4329321748de8929798f32cd0e3a446993ff4ff4cc5ecb8cdc2a1786e0b3fL101-R101)
* [`docs/attributes/forbids-constant.md`](diffhunk://#diff-789330f6a3932afc918a213d4b4469cd096cadb742bcdcb0337fd764b495bd0fL12-R12): Corrected the wording and examples to accurately reflect the behavior of the `ForbidsConstant` attribute. [[1]](diffhunk://#diff-789330f6a3932afc918a213d4b4469cd096cadb742bcdcb0337fd764b495bd0fL12-R12) [[2]](diffhunk://#diff-789330f6a3932afc918a213d4b4469cd096cadb742bcdcb0337fd764b495bd0fL84-R84) [[3]](diffhunk://#diff-789330f6a3932afc918a213d4b4469cd096cadb742bcdcb0337fd764b495bd0fL104-R104) [[4]](diffhunk://#diff-789330f6a3932afc918a213d4b4469cd096cadb742bcdcb0337fd764b495bd0fL160-R171) [[5]](diffhunk://#diff-789330f6a3932afc918a213d4b4469cd096cadb742bcdcb0337fd764b495bd0fL181-R185)
* [`src/Attribute/ForbidsClass.php`](diffhunk://#diff-658adbf5de2dfe5d8c4232370b5435dfd653f25ac4b6af716c5eb669ce58843cL30-R30): Fixed a typo in the class docblock.

### Tracer Classes for New Attributes:
* [`src/Event/Tracer/ForbidsEnvAttributeTracer.php`](diffhunk://#diff-3b9d0ecac96374c46c15a4c702bbbbaafc966247fd646d75c61eae417102bd7dR1-R66): Added a tracer class to handle the `ForbidsEnv` attribute.
* [`src/Event/Tracer/RequiresEnvAttributeTracer.php`](diffhunk://#diff-bd48b9b89d021609af62ba4701d088a2d83f38f1fb2072bce69902a709a5ec8eR1-R66): Added a tracer class to handle the `RequiresEnv` attribute.